### PR TITLE
Feat/signup controller

### DIFF
--- a/core/src/main/java/com/wemingle/core/domain/member/controller/MemberController.java
+++ b/core/src/main/java/com/wemingle/core/domain/member/controller/MemberController.java
@@ -27,7 +27,7 @@ public class MemberController {
     private final TokenService tokenService;
 
     @PostMapping("/signup")
-    ResponseEntity<?> signUpMember(@RequestBody SignUpDto.RequestSignUpDto signUpDto) { //todo 약관 정보 받아야함
+    ResponseEntity<?> signUpMember(@RequestBody SignUpDto.RequestSignUpDto signUpDto) {
         TokenDto.ResponseTokenDto unVerifiedUserTokens = tokenService.getUnVerifiedUserTokens(signUpDto.getMemberId());
         SignupVo.SaveMemberVo saveMemberVo = signUpDto.of();
         saveMemberVo.setRefreshToken(unVerifiedUserTokens.getRefreshToken());
@@ -51,11 +51,11 @@ public class MemberController {
 
         return ResponseEntity.ok().body(
                 ResponseHandler.builder()
-                        .responseMessage("Token issuance completed")
+                        .responseMessage("Profile update completed")
                         .responseData(null)
                         .build()
         );
     }
 
-//    @PostMapping("/profile")//todo 온보딩 절차 컨트롤러
+
 }

--- a/core/src/main/java/com/wemingle/core/domain/member/dto/SetMemberProfileDto.java
+++ b/core/src/main/java/com/wemingle/core/domain/member/dto/SetMemberProfileDto.java
@@ -4,9 +4,11 @@ import com.wemingle.core.domain.member.vo.SignupVo;
 import com.wemingle.core.global.annotation.Essential;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
 
 @Getter
+@NoArgsConstructor
 public class SetMemberProfileDto {
     MultipartFile profilePic;
     @Essential

--- a/core/src/main/java/com/wemingle/core/domain/member/dto/SignUpDto.java
+++ b/core/src/main/java/com/wemingle/core/domain/member/dto/SignUpDto.java
@@ -35,6 +35,12 @@ public class SignUpDto {
         @Essential
         boolean allowNotification;
 
+        @Essential
+        boolean agreeToLocationBasedServices;
+
+        @Essential
+        boolean agreeToReceiveMarketingInformation;
+
         public SignupVo.SaveMemberVo of() {
             return SignupVo.SaveMemberVo.builder()
                     .memberId(memberId)
@@ -43,6 +49,8 @@ public class SignUpDto {
                     .notifyAllow(allowNotification)
                     .firebaseToken(firebaseToken)
                     .phoneType(phoneType)
+                    .agreeToReceiveMarketingInformation(agreeToReceiveMarketingInformation)
+                    .agreeToLocationBasedServices(agreeToLocationBasedServices)
                     .build();
         }
     }

--- a/core/src/main/java/com/wemingle/core/domain/member/dto/SignUpDto.java
+++ b/core/src/main/java/com/wemingle/core/domain/member/dto/SignUpDto.java
@@ -5,13 +5,16 @@ import com.wemingle.core.domain.member.entity.signupplatform.SignupPlatform;
 import com.wemingle.core.domain.member.vo.SignupVo;
 import com.wemingle.core.global.annotation.Essential;
 import jakarta.validation.constraints.Size;
-import lombok.Value;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * DTO for {@link com.wemingle.core.domain.member.entity.Member}
  */
 public class SignUpDto {
-    @Value
+
+    @Getter
+    @NoArgsConstructor
     public static class RequestSignUpDto{
         @Essential
         String memberId;

--- a/core/src/main/java/com/wemingle/core/domain/member/vo/SignupVo.java
+++ b/core/src/main/java/com/wemingle/core/domain/member/vo/SignupVo.java
@@ -24,9 +24,12 @@ public class SignupVo {
         boolean notifyAllow;
         PhoneType phoneType;
         SignupPlatform signupPlatform;
+        boolean agreeToLocationBasedServices;
+        boolean agreeToReceiveMarketingInformation;
+
 
         @Builder
-        public SaveMemberVo(String memberId, String password, String refreshToken, String firebaseToken, boolean notifyAllow, PhoneType phoneType, SignupPlatform signupPlatform) {
+        public SaveMemberVo(String memberId, String password, String refreshToken, String firebaseToken, boolean notifyAllow, PhoneType phoneType, SignupPlatform signupPlatform, boolean agreeToLocationBasedServices, boolean agreeToReceiveMarketingInformation) {
             this.memberId = memberId;
             this.password = password;
             this.refreshToken = refreshToken;
@@ -34,7 +37,10 @@ public class SignupVo {
             this.notifyAllow = notifyAllow;
             this.phoneType = phoneType;
             this.signupPlatform = signupPlatform;
+            this.agreeToLocationBasedServices = agreeToLocationBasedServices;
+            this.agreeToReceiveMarketingInformation = agreeToReceiveMarketingInformation;
         }
+
 
         public void patchPassword(String password){
             this.password = password;


### PR DESCRIPTION
# **Pull request**

# Related issue

Feat # 31

---

## Type of change


- [x] New feature
- [ ] Refactor
- [ ] Bug fix
- [ ] Chore
- [ ] Style
- [ ] Test

---

#  📝Description

회원가입 관련 **MemberController** 구현입니다

**signUpMember()는 회원가입 기능을 담당하는 메서드입니다.**

> memberId, password, signupPlatform, phoneType, firebaseToken, allowNotification, agreeToLocationBasedServices, agreeToReceiveMarketingInformation 정보를 저장합니다.

> 회원가입이 완료되면 Access Token, Refresh Token을 발급합니다. (Roll : unVerifiedUser)

**setMemberProfile()는 회원가입 기능을 담당하는 메서드입니다.**

> profilePic(사용자 프로필 사진), nickname 정보를 추가로 저장합니다.