### PR TITLE
feat<MailController>:메일 인증 controller 구현

### DIFF
--- a/core/src/main/java/com/wemingle/core/domain/member/entity/Member.java
+++ b/core/src/main/java/com/wemingle/core/domain/member/entity/Member.java
@@ -1,11 +1,9 @@
 package com.wemingle.core.domain.member.entity;
 
 import com.wemingle.core.domain.common.entity.BaseEntity;
-import com.wemingle.core.domain.member.dto.SignUpDto;
 import com.wemingle.core.domain.member.entity.phonetype.PhoneType;
 import com.wemingle.core.domain.member.entity.role.Role;
 import com.wemingle.core.domain.member.entity.signupplatform.SignupPlatform;
-import com.wemingle.core.domain.member.vo.SignupVo;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -16,7 +14,6 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-import java.time.LocalDate;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -53,10 +50,6 @@ public class Member extends BaseEntity implements UserDetails {
     @Enumerated(EnumType.STRING)
     @Column(name = "SIGNUP_PLATFORM")
     private SignupPlatform signupPlatform;
-
-    @NotNull
-    @Column(name = "SIGNUP_DATE")
-    private LocalDate signupDate;
 
     @NotNull
     @Column(name = "REFRESH_TOKEN", columnDefinition = "VARBINARY(400) NOT NULL")

--- a/core/src/main/java/com/wemingle/core/domain/member/entity/signupplatform/SignupPlatform.java
+++ b/core/src/main/java/com/wemingle/core/domain/member/entity/signupplatform/SignupPlatform.java
@@ -1,5 +1,19 @@
 package com.wemingle.core.domain.member.entity.signupplatform;
 
 public enum SignupPlatform {
-    NAVER,KAKAO,GOOGLE,APPLE,NONE
+    KAKAO("카카오"),
+    NAVER("네이버"),
+    GOOGLE("구글"),
+    APPLE("애플"),
+    NONE("자체 회원가입");
+
+    private final String platformType;
+
+    public String getPlatformType() {
+        return platformType;
+    }
+
+    SignupPlatform(String platformType) {
+        this.platformType = platformType;
+    }
 }

--- a/core/src/main/java/com/wemingle/core/domain/memberunivemail/controller/MailController.java
+++ b/core/src/main/java/com/wemingle/core/domain/memberunivemail/controller/MailController.java
@@ -1,0 +1,88 @@
+package com.wemingle.core.domain.memberunivemail.controller;
+
+import com.wemingle.core.domain.authentication.dto.TokenDto;
+import com.wemingle.core.domain.authentication.service.TokenService;
+import com.wemingle.core.domain.member.entity.Member;
+import com.wemingle.core.domain.member.entity.signupplatform.SignupPlatform;
+import com.wemingle.core.domain.member.service.MemberService;
+import com.wemingle.core.domain.memberunivemail.dto.MailDto;
+import com.wemingle.core.domain.memberunivemail.service.MailVerificationService;
+import com.wemingle.core.domain.univ.entity.UnivEntity;
+import com.wemingle.core.domain.univ.service.UnivCertificationService;
+import com.wemingle.core.global.exceptionmessage.ExceptionMessage;
+import com.wemingle.core.global.responseform.ResponseHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/mail")
+public class MailController {
+    private final MemberService memberService;
+    private final MailVerificationService mailVerificationService;
+    private final UnivCertificationService univCertificationService;
+    private final TokenService tokenService;
+
+    private final static String IS_REGISTERED_PLATFORM_SUFFIX = "로 이미 가입된 학교 이메일입니다";
+
+    @PostMapping()
+    public ResponseEntity<?> sendMail(@RequestBody MailDto.RequestSendMailDto requestSendMailDto,
+                                      @AuthenticationPrincipal UserDetails userDetails){
+        String memberId = userDetails.getUsername();
+        Member findMember = memberService.findByMemberId(memberId);
+
+        String requestUnivEmail = requestSendMailDto.getUnivEmail();
+        String registeredPlatform = mailVerificationService.getRegisteredPlatform(requestUnivEmail);
+        if (isRegisteredUnivEmail(registeredPlatform)){
+            SignupPlatform signupPlatform = SignupPlatform.valueOf(registeredPlatform);
+            return ResponseEntity
+                    .status(HttpStatus.CONFLICT)
+                    .body(ResponseHandler.<MailDto.ResponseRegisteredPlatformDto>builder()
+                            .responseMessage(signupPlatform.getPlatformType() + IS_REGISTERED_PLATFORM_SUFFIX)
+                            .responseData(new MailDto.ResponseRegisteredPlatformDto(signupPlatform.getPlatformType()))
+                            .build());
+        }
+
+        mailVerificationService.sendVerificationMail(requestUnivEmail, findMember);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    private boolean isRegisteredUnivEmail(String registeredPlatform){
+        return !registeredPlatform.equals(ExceptionMessage.UNREGISTERED_MEMBER.toString());
+    }
+
+    @PostMapping("/verify")
+    public ResponseEntity<?> verifyCode(@RequestBody MailDto.RequestVerifyCodeDto requestVerifyCodeDto,
+                                        @AuthenticationPrincipal UserDetails userDetails){
+        String memberId = userDetails.getUsername();
+        Member findMember = memberService.findByMemberId(memberId);
+
+        if(!mailVerificationService.validVerificationCode(memberId, requestVerifyCodeDto.getVerificationCode())){
+            return ResponseEntity
+                    .status(HttpStatus.BAD_REQUEST)
+                    .body(ResponseHandler.builder()
+                            .responseMessage("코드가 일치하지않습니다.")
+                            .responseData(null)
+                            .build());
+        }
+
+        String univDomain = univCertificationService.getDomainInMailAddress(requestVerifyCodeDto.getUnivEmail());
+        UnivEntity univEntity = univCertificationService.findByDomain(univDomain);
+        mailVerificationService.saveVerifiedUniversityEmail(findMember, univEntity);
+        TokenDto.ResponseTokenDto renewalToken = tokenService.getTokensAndConvertToAuthenticationUser(findMember);
+
+        return ResponseEntity.ok(
+                ResponseHandler.<TokenDto.ResponseTokenDto>builder()
+                        .responseMessage("인증이 완료되어 토큰을 재발급합니다.")
+                        .responseData(renewalToken)
+                        .build());
+    }
+}

--- a/core/src/main/java/com/wemingle/core/domain/memberunivemail/dto/MailDto.java
+++ b/core/src/main/java/com/wemingle/core/domain/memberunivemail/dto/MailDto.java
@@ -1,0 +1,47 @@
+package com.wemingle.core.domain.memberunivemail.dto;
+
+import com.wemingle.core.global.annotation.Essential;
+import jakarta.validation.constraints.Email;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class MailDto {
+    @Getter
+    @NoArgsConstructor
+    public static class RequestSendMailDto{
+        @Essential @Email
+        String univEmail;
+
+        @Builder
+        public RequestSendMailDto(String univEmail) {
+            this.univEmail = univEmail;
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class ResponseRegisteredPlatformDto{
+        String registeredPlatform;
+
+        public ResponseRegisteredPlatformDto(String registeredPlatform) {
+            this.registeredPlatform = registeredPlatform;
+        }
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class RequestVerifyCodeDto{
+        @Essential @Email
+        String univEmail;
+        String verificationCode;
+
+        @Builder
+        public RequestVerifyCodeDto(String univEmail, String verificationCode) {
+            this.univEmail = univEmail;
+            this.verificationCode = verificationCode;
+        }
+    }
+}

--- a/core/src/main/java/com/wemingle/core/domain/memberunivemail/entity/VerifiedUniversityEmail.java
+++ b/core/src/main/java/com/wemingle/core/domain/memberunivemail/entity/VerifiedUniversityEmail.java
@@ -8,10 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Entity
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class VerifiedUniversityEmail extends BaseEntity {
@@ -31,6 +28,12 @@ public class VerifiedUniversityEmail extends BaseEntity {
     @Column(name = "UNIV_EMAIL_ADDRESS")
     private String univEmailAddress;
 
-    @Column(name = "VERIFIED_DATE")
-    private LocalDateTime verifiedDate;
+    @Builder
+    public VerifiedUniversityEmail(Member member, UnivEntity univName, String univEmailAddress) {
+        this.member = member;
+        this.univName = univName;
+        this.univEmailAddress = univEmailAddress;
+    }
+
+
 }

--- a/core/src/main/java/com/wemingle/core/domain/univ/entity/UnivEntity.java
+++ b/core/src/main/java/com/wemingle/core/domain/univ/entity/UnivEntity.java
@@ -3,6 +3,7 @@ package com.wemingle.core.domain.univ.entity;
 import com.wemingle.core.domain.univ.CityCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,4 +26,10 @@ public class UnivEntity {
     @Column(name = "CITY_CODE")
     private CityCode cityCode;
 
+    @Builder
+    public UnivEntity(String univName, String domain, CityCode cityCode) {
+        this.univName = univName;
+        this.domain = domain;
+        this.cityCode = cityCode;
+    }
 }

--- a/core/src/main/java/com/wemingle/core/domain/univ/service/UnivCertificationService.java
+++ b/core/src/main/java/com/wemingle/core/domain/univ/service/UnivCertificationService.java
@@ -1,10 +1,12 @@
 package com.wemingle.core.domain.univ.service;
 
+import com.wemingle.core.domain.univ.entity.UnivEntity;
 import com.wemingle.core.domain.univ.repository.UnivRepository;
+import com.wemingle.core.global.exceptionmessage.ExceptionMessage;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @RequiredArgsConstructor
@@ -22,5 +24,10 @@ public class UnivCertificationService {
         Pattern pattern = Pattern.compile(domainRegex);
 
         return pattern.matcher(mailAddress).group(1);
+    }
+
+    public UnivEntity findByDomain(String univDomain){
+        return univRepository.findByDomain(univDomain).orElseThrow(() -> new EntityNotFoundException(
+                ExceptionMessage.UNIV_DOMAIN_NOT_FOUND.getExceptionMessage()));
     }
 }


### PR DESCRIPTION
# **Pull request**

# Related issue

Close #25 

---

## Type of change


- [x] New feature
- [ ] Refactor
- [ ] Bug fix
- [ ] Chore
- [ ] Style
- [ ] Test

---

#  📝Description

메일 인증 관련 MailController 구현했습니다.

**sendMail()는** 학교 이메일에 인증 코드를 보내는 api입니다.
> 이미 등록된 학교 이메일인 경우에는 어느 플랫폼에서 가입을 했었지 응답합니다.

> 등록된 학교 이메일이 아닐 시에 해당 이메일로 인증코드를 보냅니다.

**verifyCode는** 사용자가 보낸 인증코드를 검증하는 api입니다
> 인증코드의 검증 성공 시 해당 학교 이메일을 저장하고 RefreshToken과 AccessToken을 재발급합니다.(Role : User)
> 재발급된 RefreshToken으로 member에 저장된 RefreshToken을 수정합니다.

