### PR TITLE
refactor<MemberServiceImpl>: 회원 가입 로직 수정

### DIFF
--- a/core/src/main/java/com/wemingle/core/domain/member/entity/Member.java
+++ b/core/src/main/java/com/wemingle/core/domain/member/entity/Member.java
@@ -146,4 +146,8 @@ public class Member extends BaseEntity implements UserDetails {
         this.refreshToken = newRefreshToken;
         this.role = Role.USER;
     }
+
+    public void patchPolicyTerms(PolicyTerms policyTerms){
+        this.policyTerms = policyTerms;
+    }
 }

--- a/core/src/main/java/com/wemingle/core/domain/member/entity/PolicyTerms.java
+++ b/core/src/main/java/com/wemingle/core/domain/member/entity/PolicyTerms.java
@@ -3,8 +3,12 @@ package com.wemingle.core.domain.member.entity;
 import com.wemingle.core.domain.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PolicyTerms extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "pk")
@@ -12,13 +16,30 @@ public class PolicyTerms extends BaseEntity {
 
     @NotNull
     @Column(name = "POLICY_1")
-    private Boolean policy1;
+    private boolean policy1;
 
     @NotNull
     @Column(name = "POLICY_2")
-    private Boolean policy2;
+    private boolean policy2;
 
     @NotNull
     @Column(name = "POLICY_3")
-    private Boolean policy3;
+    private boolean policy3;
+
+    @NotNull
+    @Column(name = "AGREE_TO_LOCATION_BASED_SERVICES")
+    private boolean agreeToLocationBasedServices;
+
+    @NotNull
+    @Column(name = "AGREE_TO_RECEIVE_MARKETING_INFORMATION")
+    private boolean agreeToReceiveMarketingInformation;
+
+    @Builder
+    public PolicyTerms(boolean agreeToLocationBasedServices, boolean agreeToReceiveMarketingInformation) {
+        this.policy1 = true;
+        this.policy2 = true;
+        this.policy3 = true;
+        this.agreeToLocationBasedServices = agreeToLocationBasedServices;
+        this.agreeToReceiveMarketingInformation = agreeToReceiveMarketingInformation;
+    }
 }

--- a/core/src/main/java/com/wemingle/core/domain/member/repository/PolicyTermsRepository.java
+++ b/core/src/main/java/com/wemingle/core/domain/member/repository/PolicyTermsRepository.java
@@ -1,0 +1,7 @@
+package com.wemingle.core.domain.member.repository;
+
+import com.wemingle.core.domain.member.entity.PolicyTerms;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PolicyTermsRepository extends JpaRepository<PolicyTerms, Long> {
+}

--- a/core/src/main/java/com/wemingle/core/domain/member/service/MemberServiceImpl.java
+++ b/core/src/main/java/com/wemingle/core/domain/member/service/MemberServiceImpl.java
@@ -39,13 +39,10 @@ public class MemberServiceImpl implements MemberService {
     }
 
     private PolicyTerms savePolicyTerms(boolean agreeToLocationBasedServices, boolean agreeToReceiveMarketingInformation){
-        PolicyTerms policyTerms = PolicyTerms.builder()
+        return policyTermsRepository.save(PolicyTerms.builder()
                 .agreeToLocationBasedServices(agreeToLocationBasedServices)
                 .agreeToReceiveMarketingInformation(agreeToReceiveMarketingInformation)
-                .build();
-        policyTermsRepository.save(policyTerms);
-
-        return policyTerms;
+                .build());
     }
 
     @Override

--- a/core/src/main/java/com/wemingle/core/domain/member/service/MemberServiceImpl.java
+++ b/core/src/main/java/com/wemingle/core/domain/member/service/MemberServiceImpl.java
@@ -1,7 +1,9 @@
 package com.wemingle.core.domain.member.service;
 
 import com.wemingle.core.domain.member.entity.Member;
+import com.wemingle.core.domain.member.entity.PolicyTerms;
 import com.wemingle.core.domain.member.repository.MemberRepository;
+import com.wemingle.core.domain.member.repository.PolicyTermsRepository;
 import com.wemingle.core.domain.member.vo.SignupVo;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,7 @@ import static com.wemingle.core.global.exceptionmessage.ExceptionMessage.MEMBER_
 public class MemberServiceImpl implements MemberService {
     private final MemberRepository memberRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    private final PolicyTermsRepository policyTermsRepository;
 
     @Override
     public boolean verifyAvailableId(String memberId) {
@@ -27,9 +30,22 @@ public class MemberServiceImpl implements MemberService {
     @Override
     @Transactional
     public void saveMember(SignupVo.SaveMemberVo saveMemberVo) {
+        PolicyTerms policyTerms = savePolicyTerms(saveMemberVo.isAgreeToLocationBasedServices(), saveMemberVo.isAgreeToReceiveMarketingInformation());
         saveMemberVo.patchPassword(bCryptPasswordEncoder.encode(saveMemberVo.getPassword()));
         Member member = saveMemberVo.of(saveMemberVo);
+        member.patchPolicyTerms(policyTerms);
+
         memberRepository.save(member);
+    }
+
+    private PolicyTerms savePolicyTerms(boolean agreeToLocationBasedServices, boolean agreeToReceiveMarketingInformation){
+        PolicyTerms policyTerms = PolicyTerms.builder()
+                .agreeToLocationBasedServices(agreeToLocationBasedServices)
+                .agreeToReceiveMarketingInformation(agreeToReceiveMarketingInformation)
+                .build();
+        policyTermsRepository.save(policyTerms);
+
+        return policyTerms;
     }
 
     @Override


### PR DESCRIPTION
* saveMember 메소드에서 회원 저장 시 약관동의도 같이 저장하도록 수정

# **Pull request**

# Related issue

Fixes #37 

---

## Type of change


- [ ] New feature
- [x] Refactor
- [ ] Bug fix
- [ ] Chore
- [ ] Style
- [ ] Test

---

#  📝Description

약관 동의에 대한 기획이 확정돼서 확정 전에 구현한 saveMember 메소드에서 회원 저장 전에 약관동의를 같이 저장하도록 수정하였습니다.