### PR TITLE
refactor<MailVerificationService>: 이메일 인증 후 인증 이메일 저장 시 개인팀 생성 후 저장하는…

### DIFF
--- a/core/src/main/java/com/wemingle/core/domain/category/sports/repository/SportsCategoryRepository.java
+++ b/core/src/main/java/com/wemingle/core/domain/category/sports/repository/SportsCategoryRepository.java
@@ -11,4 +11,7 @@ import java.util.List;
 public interface SportsCategoryRepository extends JpaRepository<SportsCategory, Long> {
     @Query("select sc from SportsCategory sc where sc.sportsName in :sportsTypes")
     List<SportsCategory> findBySportsTypes(@Param("sportsTypes") List<SportsType> sportsTypes);
+
+    @Query("select sc from SportsCategory sc where sc.sportsName = :sportsType")
+    SportsCategory findBySportsType(@Param("sportsType") SportsType sportsType);
 }


### PR DESCRIPTION
… 로직 추가

# **Pull request**

# Related issue

close #58 

---

## Type of change


- [ ] New feature
- [x] Refactor
- [ ] Bug fix
- [ ] Chore
- [ ] Style
- [ ] Test

---

#  📝Description

회원이 이메일 인증을 완료하여 학교 이메일을 저장하는 시점에 개인 팀을 생성하여 저장함으로써 개인으로 활동할 수 있도록 함
