### PR TITLE
feat<TeamController>: 사용자별 팀 정보 조회 api 구현

### DIFF
--- a/core/src/main/java/com/wemingle/core/domain/team/controller/TeamController.java
+++ b/core/src/main/java/com/wemingle/core/domain/team/controller/TeamController.java
@@ -1,0 +1,33 @@
+package com.wemingle.core.domain.team.controller;
+
+import com.wemingle.core.domain.team.dto.TeamDto;
+import com.wemingle.core.domain.team.service.TeamService;
+import com.wemingle.core.global.responseform.ResponseHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/team")
+public class TeamController {
+    private final TeamService teamService;
+
+    @GetMapping
+    public ResponseEntity<ResponseHandler<HashMap<Long, TeamDto.ResponseTeamInfoDto>>> getTeamInfoByMemberId(@AuthenticationPrincipal UserDetails userDetails){
+        HashMap<Long, TeamDto.ResponseTeamInfoDto> teamListInfo = teamService.getTeamInfoWithMemberId(userDetails.getUsername());
+
+        return ResponseEntity.ok(
+                ResponseHandler.<HashMap<Long, TeamDto.ResponseTeamInfoDto>>builder()
+                        .responseMessage("Teams info retrieval successfully")
+                        .responseData(teamListInfo)
+                        .build()
+        );
+    }
+}

--- a/core/src/main/java/com/wemingle/core/domain/team/dto/TeamDto.java
+++ b/core/src/main/java/com/wemingle/core/domain/team/dto/TeamDto.java
@@ -1,0 +1,20 @@
+package com.wemingle.core.domain.team.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class TeamDto {
+    @Getter
+    @NoArgsConstructor
+    public static class ResponseTeamInfoDto {
+        String teamName;
+        String teamImgUrl;
+
+        @Builder
+        public ResponseTeamInfoDto(String teamName, String teamImgUrl) {
+            this.teamName = teamName;
+            this.teamImgUrl = teamImgUrl;
+        }
+    }
+}

--- a/core/src/main/java/com/wemingle/core/domain/team/repository/TeamRepository.java
+++ b/core/src/main/java/com/wemingle/core/domain/team/repository/TeamRepository.java
@@ -3,5 +3,8 @@ package com.wemingle.core.domain.team.repository;
 import com.wemingle.core.domain.team.entity.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TeamRepository extends JpaRepository<Team, Long> {
+    List<Team> findByTeamOwner_MemberId(String memberId);
 }

--- a/core/src/main/java/com/wemingle/core/domain/team/service/TeamService.java
+++ b/core/src/main/java/com/wemingle/core/domain/team/service/TeamService.java
@@ -1,0 +1,9 @@
+package com.wemingle.core.domain.team.service;
+
+import com.wemingle.core.domain.team.dto.TeamDto;
+
+import java.util.HashMap;
+
+public interface TeamService {
+    HashMap<Long, TeamDto.ResponseTeamInfoDto> getTeamInfoWithMemberId(String memberId);
+}

--- a/core/src/main/java/com/wemingle/core/domain/team/service/TeamServiceImpl.java
+++ b/core/src/main/java/com/wemingle/core/domain/team/service/TeamServiceImpl.java
@@ -1,0 +1,34 @@
+package com.wemingle.core.domain.team.service;
+
+import com.wemingle.core.domain.img.service.S3ImgService;
+import com.wemingle.core.domain.team.dto.TeamDto;
+import com.wemingle.core.domain.team.entity.Team;
+import com.wemingle.core.domain.team.repository.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TeamServiceImpl implements TeamService{
+    private final TeamRepository teamRepository;
+    private final S3ImgService s3ImgService;
+    @Override
+    public HashMap<Long, TeamDto.ResponseTeamInfoDto> getTeamInfoWithMemberId(String memberId) {
+        List<Team> teamList = teamRepository.findByTeamOwner_MemberId(memberId);
+
+        HashMap<Long, TeamDto.ResponseTeamInfoDto> responseTeamInfo = new HashMap<>();
+
+        teamList.forEach(team -> responseTeamInfo.put(team.getPk(),
+                        TeamDto.ResponseTeamInfoDto.builder()
+                                .teamName(team.getTeamName())
+                                .teamImgUrl(s3ImgService.getGroupProfilePicUrl(team.getProfileImgId()))
+                                .build()));
+
+        return responseTeamInfo;
+    }
+}


### PR DESCRIPTION
# **Pull request**

# Related issue

close #69 

---

## Type of change


- [x] New feature
- [ ] Refactor
- [ ] Bug fix
- [ ] Chore
- [ ] Style
- [ ] Test

---

#  📝Description

1. controller에 getTeamINfoByMemberId(사용자별 팀 정보 조회하는 메소드) 구현
  > 필요한 파라미터는 없으며 사용자가 속한 팀들의 정보를 조회합니다.
2. service에 getTeamInfoWithMemberId 메소드 구현
  > 사용자가 속한 팀의 정보를 hashMap으로 변환하여 리턴합니다. 

