### PR TITLE
refactor<MatchingPostController,MatchingPostService> 

### DIFF
--- a/core/src/main/java/com/wemingle/core/domain/post/controller/MatchingPostController.java
+++ b/core/src/main/java/com/wemingle/core/domain/post/controller/MatchingPostController.java
@@ -1,8 +1,8 @@
 package com.wemingle.core.domain.post.controller;
 
 import com.wemingle.core.domain.post.dto.MatchingPostDto;
-import com.wemingle.core.domain.post.entity.MatchingPostArea;
 import com.wemingle.core.domain.post.entity.abillity.Ability;
+import com.wemingle.core.domain.post.entity.area.AreaName;
 import com.wemingle.core.domain.post.entity.gender.Gender;
 import com.wemingle.core.domain.post.entity.recruitertype.RecruiterType;
 import com.wemingle.core.domain.post.service.MatchingPostService;
@@ -41,7 +41,7 @@ public class MatchingPostController {
                                                                                        @RequestParam(required = false) Ability ability,
                                                                                        @RequestParam(required = false) Gender gender,
                                                                                        @RequestParam(required = false) RecruiterType recruiterType,
-                                                                                       @RequestParam(required = false) List<MatchingPostArea> areaList,
+                                                                                       @RequestParam(required = false) List<AreaName> areaList,
                                                                                        @RequestParam(required = false) LocalDate dateFilter,
                                                                                        @RequestParam(required = false) Boolean excludeExpired,
                                                                                        @AuthenticationPrincipal UserDetails userDetails){

--- a/core/src/main/java/com/wemingle/core/domain/post/repository/DSLMatchingPostRepository.java
+++ b/core/src/main/java/com/wemingle/core/domain/post/repository/DSLMatchingPostRepository.java
@@ -1,8 +1,8 @@
 package com.wemingle.core.domain.post.repository;
 
 import com.wemingle.core.domain.post.entity.MatchingPost;
-import com.wemingle.core.domain.post.entity.MatchingPostArea;
 import com.wemingle.core.domain.post.entity.abillity.Ability;
+import com.wemingle.core.domain.post.entity.area.AreaName;
 import com.wemingle.core.domain.post.entity.gender.Gender;
 import com.wemingle.core.domain.post.entity.recruitertype.RecruiterType;
 import com.wemingle.core.domain.team.entity.recruitmenttype.RecruitmentType;
@@ -13,6 +13,6 @@ import java.util.List;
 
 public interface DSLMatchingPostRepository {
 
-    List<MatchingPost> findFilteredMatchingPost(Long nextIdx, RecruitmentType recruitmentType, Ability ability, Gender gender, RecruiterType recruiterType, List<MatchingPostArea> areaList, LocalDate currentDate, LocalDate dateFilter, Pageable pageable);
+    List<MatchingPost> findFilteredMatchingPost(Long nextIdx, RecruitmentType recruitmentType, Ability ability, Gender gender, RecruiterType recruiterType, List<AreaName> areaList, LocalDate currentDate, LocalDate dateFilter, Pageable pageable);
 
 }

--- a/core/src/main/java/com/wemingle/core/domain/post/repository/DSLMatchingPostRepositoryImpl.java
+++ b/core/src/main/java/com/wemingle/core/domain/post/repository/DSLMatchingPostRepositoryImpl.java
@@ -3,8 +3,8 @@ package com.wemingle.core.domain.post.repository;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.wemingle.core.domain.post.entity.MatchingPost;
-import com.wemingle.core.domain.post.entity.MatchingPostArea;
 import com.wemingle.core.domain.post.entity.abillity.Ability;
+import com.wemingle.core.domain.post.entity.area.AreaName;
 import com.wemingle.core.domain.post.entity.gender.Gender;
 import com.wemingle.core.domain.post.entity.recruitertype.RecruiterType;
 import com.wemingle.core.domain.team.entity.recruitmenttype.RecruitmentType;
@@ -28,7 +28,7 @@ public class DSLMatchingPostRepositoryImpl implements DSLMatchingPostRepository{
                                                        Ability ability,
                                                        Gender gender,
                                                        RecruiterType recruiterType,
-                                                       List<MatchingPostArea> areaList,
+                                                       List<AreaName> areaList,
                                                        LocalDate currentDate,
                                                        LocalDate dateFilter,
                                                        Pageable pageable) {
@@ -71,8 +71,8 @@ public class DSLMatchingPostRepositoryImpl implements DSLMatchingPostRepository{
     private BooleanExpression recruiterTypeEq(RecruiterType recruiterType) {
         return recruiterType == null ? null : matchingPost.recruiterType.eq(recruiterType);
     }
-    private BooleanExpression areaListIn(List<MatchingPostArea> areaList) {
-        return areaList == null ? null : matchingPost.areaList.any().in(areaList);
+    private BooleanExpression areaListIn(List<AreaName> areaList) {
+        return areaList == null ? null : matchingPost.areaList.any().areaName.in(areaList);
     }
 
     private BooleanExpression currentDateAfter(LocalDate currentDate) {

--- a/core/src/main/java/com/wemingle/core/domain/post/service/MatchingPostService.java
+++ b/core/src/main/java/com/wemingle/core/domain/post/service/MatchingPostService.java
@@ -11,6 +11,7 @@ import com.wemingle.core.domain.post.dto.MatchingPostDto;
 import com.wemingle.core.domain.post.entity.MatchingPost;
 import com.wemingle.core.domain.post.entity.MatchingPostArea;
 import com.wemingle.core.domain.post.entity.abillity.Ability;
+import com.wemingle.core.domain.post.entity.area.AreaName;
 import com.wemingle.core.domain.post.entity.gender.Gender;
 import com.wemingle.core.domain.post.entity.recruitertype.RecruiterType;
 import com.wemingle.core.domain.post.repository.MatchingPostRepository;
@@ -60,7 +61,7 @@ public class MatchingPostService {
                                                     Ability ability,
                                                     Gender gender,
                                                     RecruiterType recruiterType,
-                                                    List<MatchingPostArea> areaList,
+                                                    List<AreaName> areaList,
                                                     LocalDate dateFilter,
                                                     Boolean excludeExpired){
 


### PR DESCRIPTION
areaList의 리스트 제네릭 타입을 MatchingPostArea -> AreaName으로 변경

# **Pull request**

# Related issue

close #79 

---

## Type of change


- [ ] New feature
- [x] Refactor
- [ ] Bug fix
- [ ] Chore
- [ ] Style
- [ ] Test

---

#  📝Description
MatchingPostController의 getMatchingPostByCalender() 매서드 매개변수 areaList의 리스트 제네릭 타입을 MatchingPostArea -> AreaName으로 변경

