### PR TITLE
fix<TeamServiceImpl> : 개인팀인지 구별하여 팀 프로필 사진url 발급

### DIFF
--- a/core/src/main/java/com/wemingle/core/domain/team/service/TeamServiceImpl.java
+++ b/core/src/main/java/com/wemingle/core/domain/team/service/TeamServiceImpl.java
@@ -26,9 +26,15 @@ public class TeamServiceImpl implements TeamService{
         teamList.forEach(team -> responseTeamInfo.put(team.getPk(),
                         TeamDto.ResponseTeamInfoDto.builder()
                                 .teamName(team.getTeamName())
-                                .teamImgUrl(s3ImgService.getGroupProfilePicUrl(team.getProfileImgId()))
+                                .teamImgUrl(getTeamImgUrl(memberId, team))
                                 .build()));
 
         return responseTeamInfo;
+    }
+
+    private String getTeamImgUrl(String memberId, Team team) {
+        return team.getTeamName().equals(memberId) 
+                ? s3ImgService.getMemberProfilePicUrl(team.getProfileImgId())
+                : s3ImgService.getGroupProfilePicUrl(team.getProfileImgId());
     }
 }


### PR DESCRIPTION
# **Pull request**

# Related issue

fix #82 

---

## Type of change


- [ ] New feature
- [ ] Refactor
- [x] Bug fix
- [ ] Chore
- [ ] Style
- [ ] Test

---

#  📝Description

개인팀과 기존 팀을 구별하지 않고 프로필 사진url을 발급하던 것을 구별하여 발급하도록 수정하였습니다