### PR TITLE
fix<MatchingPostService>: teamOwner도 matching에 저장

### DIFF
--- a/core/src/main/java/com/wemingle/core/domain/post/service/MatchingPostService.java
+++ b/core/src/main/java/com/wemingle/core/domain/post/service/MatchingPostService.java
@@ -28,13 +28,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.NoSuchElementException;
+import java.util.*;
 
-import static com.wemingle.core.global.exceptionmessage.ExceptionMessage.TEAM_MEMBER_NOT_FOUND;
-import static com.wemingle.core.global.exceptionmessage.ExceptionMessage.TEAM_NOT_FOUND;
+import static com.wemingle.core.global.exceptionmessage.ExceptionMessage.*;
 
 @Slf4j
 @Service
@@ -118,13 +114,26 @@ public class MatchingPostService {
         MatchingPost matchingPost = createMatchingPostDto.of(team, writerInTeam);
         matchingPostRepository.save(matchingPost);
 
+        Member teamOwner = memberRepository.findByMemberId(writerId).orElseThrow(() -> new EntityNotFoundException(MEMBER_NOT_FOUNT.getExceptionMessage()));
+        saveMatchingOwner(team, teamOwner, matchingPost);
+
         if (isExistTeamParticipant(recruiterType, participantsId)){
             List<Member> memberList = memberRepository.findByMemberIdIn(participantsId);
-            createParticipants(team, memberList, matchingPost);
+            saveMatchingParticipants(team, memberList, matchingPost);
         }
     }
 
-    private void createParticipants(Team team, List<Member> memberList, MatchingPost matchingPost) {
+    private void saveMatchingOwner(Team team, Member member, MatchingPost matchingPost) {
+        Matching matchingTeamOwner = Matching.builder()
+                        .matchingPost(matchingPost)
+                        .member(member)
+                        .team(team)
+                        .build();
+
+        matchingRepository.save(matchingTeamOwner);
+    }
+
+    private void saveMatchingParticipants(Team team, List<Member> memberList, MatchingPost matchingPost) {
         List<Matching> matchingParticipantList = memberList.stream().map(member -> Matching.builder()
                         .matchingPost(matchingPost)
                         .member(member)


### PR DESCRIPTION
# **Pull request**

# Related issue

fix #91 

---

## Type of change


- [ ] New feature
- [ ] Refactor
- [x] Bug fix
- [ ] Chore
- [ ] Style
- [ ] Test

---

#  📝Description

매칭글 저장할 때 같이 참가할 팀의 멤버들과 함께 팀장도 matching 테이블에 저장하도록 변경하였습니다
