### PR TITLE
feat<MatchingPostController>: 매칭리스트에서 매칭 완료된 글들 조회하는 api 구현

### DIFF
--- a/core/src/main/java/com/wemingle/core/domain/matching/entity/MatchingRequest.java
+++ b/core/src/main/java/com/wemingle/core/domain/matching/entity/MatchingRequest.java
@@ -1,8 +1,9 @@
 package com.wemingle.core.domain.matching.entity;
 
 import com.wemingle.core.domain.common.entity.BaseEntity;
+import com.wemingle.core.domain.member.entity.Member;
 import com.wemingle.core.domain.post.entity.MatchingPost;
-import com.wemingle.core.domain.team.entity.TeamMember;
+import com.wemingle.core.domain.team.entity.Team;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -16,8 +17,12 @@ public class MatchingRequest extends BaseEntity {
     private Long pk;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "TEAM_MEMBER")
-    private TeamMember teamMember;
+    @JoinColumn(name = "TEAM")
+    private Team team;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "MEMBER")
+    private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "MATCHIN_POST")

--- a/core/src/main/java/com/wemingle/core/domain/matching/repository/MatchingRequestRepository.java
+++ b/core/src/main/java/com/wemingle/core/domain/matching/repository/MatchingRequestRepository.java
@@ -6,8 +6,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface MatchingRequestRepository extends JpaRepository<MatchingRequest, Long> {
-    @Query("select count(*) from MatchingRequest m where m.teamMember.member.memberId = :memberId ")
-    Integer findRequestedMatchingCnt(@Param("memberId") String memberId);
+//    @Query("select count(*) from MatchingRequest m where m.teamMember.member.memberId = :memberId ")
+//    Integer findRequestedMatchingCnt(@Param("memberId") String memberId);
 
     @Query("select count(*) from MatchingRequest m where m.matchingPost.writer.member.memberId = :memberId ")
     Integer findReceivedMatchingCnt(@Param("memberId") String memberId);

--- a/core/src/main/java/com/wemingle/core/domain/matching/service/MatchingService.java
+++ b/core/src/main/java/com/wemingle/core/domain/matching/service/MatchingService.java
@@ -17,12 +17,12 @@ public class MatchingService {
     public LinkedHashMap<String, Integer> getMatchingSummaryInfo(String memberId) {
         Integer completeMatchingCnt = matchingRepository.findCompleteMatchingCnt(memberId, MatchingStatus.COMPLETE);
         Integer scheduledMatchingCnt = matchingRepository.findScheduledMatchingCnt(memberId);
-        Integer requestedMatchingCnt = matchingRequestRepository.findRequestedMatchingCnt(memberId);
+//        Integer requestedMatchingCnt = matchingRequestRepository.findRequestedMatchingCnt(memberId);
         Integer receivedMatchingCnt = matchingRequestRepository.findReceivedMatchingCnt(memberId);
         LinkedHashMap<String, Integer> responseNode = new LinkedHashMap<>();
         responseNode.put("completeMatchingCnt", completeMatchingCnt);
         responseNode.put("scheduledMatchingCnt", scheduledMatchingCnt);
-        responseNode.put("requestedMatchingCnt", requestedMatchingCnt);
+//        responseNode.put("requestedMatchingCnt", requestedMatchingCnt);
         responseNode.put("receivedMatchingCnt", receivedMatchingCnt);
         return responseNode;
     }

--- a/core/src/main/java/com/wemingle/core/domain/memberunivemail/service/MailVerificationService.java
+++ b/core/src/main/java/com/wemingle/core/domain/memberunivemail/service/MailVerificationService.java
@@ -8,6 +8,7 @@ import com.wemingle.core.domain.memberunivemail.repository.VerifiedUniversityEma
 import com.wemingle.core.domain.team.entity.Team;
 import com.wemingle.core.domain.team.entity.TeamMember;
 import com.wemingle.core.domain.team.entity.teamrole.TeamRole;
+import com.wemingle.core.domain.team.entity.teamtype.TeamType;
 import com.wemingle.core.domain.team.repository.TeamMemberRepository;
 import com.wemingle.core.domain.team.repository.TeamRepository;
 import com.wemingle.core.domain.univ.entity.UnivEntity;
@@ -90,6 +91,7 @@ public class MailVerificationService {
         Team team = Team.builder()
                 .teamName(member.getMemberId())
                 .teamOwner(member)
+                .teamType(TeamType.INDIVIDUAL)
                 .profileImgId(member.getProfileImgId())
                 .sportsCategory(sportsCategoryRepository.findBySportsType(SportsType.OTHER))
                 .capacityLimit(1)

--- a/core/src/main/java/com/wemingle/core/domain/post/controller/MatchingPostController.java
+++ b/core/src/main/java/com/wemingle/core/domain/post/controller/MatchingPostController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 @RestController
@@ -54,4 +55,17 @@ public class MatchingPostController {
         );
     }
 
+    @GetMapping("/completion")
+    public ResponseEntity<ResponseHandler<LinkedHashMap<Long, MatchingPostDto.ResponseCompletedMatchingPost>>> getCompletedMatchingPosts(@RequestParam(required = false) Long nextIdx,
+                                                                                                                                         @RequestParam(required = false) RecruiterType recruiterType,
+                                                                                                                                         @RequestParam boolean excludeCompleteMatchesFilter,
+                                                                                                                                         @AuthenticationPrincipal UserDetails userDetails) {
+        LinkedHashMap<Long, MatchingPostDto.ResponseCompletedMatchingPost> completedMatchingPosts =
+                matchingPostService.getCompletedMatchingPosts(nextIdx, recruiterType, excludeCompleteMatchesFilter, userDetails.getUsername());
+
+        return ResponseEntity.ok(ResponseHandler.<LinkedHashMap<Long, MatchingPostDto.ResponseCompletedMatchingPost>>builder()
+                .responseMessage("completed matching posts retrieval successfully")
+                .responseData(completedMatchingPosts)
+                .build());
+    }
 }

--- a/core/src/main/java/com/wemingle/core/domain/post/dto/MatchingPostDto.java
+++ b/core/src/main/java/com/wemingle/core/domain/post/dto/MatchingPostDto.java
@@ -137,4 +137,51 @@ public class MatchingPostDto {
             return matchingPost;
         }
     }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class ResponseCompletedMatchingPost {
+        private LocalDate matchingDate;
+        private RecruiterType recruiterType;
+        private String teamName;
+        private int completedMatchingCnt;
+        private String content;
+        private List<AreaName> areaNames;
+        private boolean isLocationConsensusPossible;
+        private Ability ability;
+        private String profileImgUrl;
+        private String detailPostUrl;
+        private String matchingStatus;
+        private ScheduledRequest scheduledRequest;
+
+        @Builder
+        public ResponseCompletedMatchingPost(LocalDate matchingDate, RecruiterType recruiterType, String teamName, int completedMatchingCnt, String content, List<AreaName> areaNames, boolean isLocationConsensusPossible, Ability ability, String profileImgUrl, String detailPostUrl, String matchingStatus, ScheduledRequest scheduledRequest) {
+            this.matchingDate = matchingDate;
+            this.recruiterType = recruiterType;
+            this.teamName = teamName;
+            this.completedMatchingCnt = completedMatchingCnt;
+            this.content = content;
+            this.areaNames = areaNames;
+            this.isLocationConsensusPossible = isLocationConsensusPossible;
+            this.ability = ability;
+            this.profileImgUrl = profileImgUrl;
+            this.detailPostUrl = detailPostUrl;
+            this.matchingStatus = matchingStatus;
+            this.scheduledRequest = scheduledRequest;
+        }
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class ScheduledRequest {
+        private String description;
+        private String requestApiUri;
+
+        public ScheduledRequest(String description, String requestApiUri) {
+            this.description = description;
+            this.requestApiUri = requestApiUri;
+        }
+    }
 }

--- a/core/src/main/java/com/wemingle/core/domain/post/entity/MatchingPost.java
+++ b/core/src/main/java/com/wemingle/core/domain/post/entity/MatchingPost.java
@@ -103,7 +103,7 @@ public class MatchingPost extends BaseEntity {
         this.gender = gender;
         this.recruitmentType = recruitmentType;
         this.recruiterType = recruiterType;
-        this.matchingStatus = MatchingStatus.PENDING;
+        this.matchingStatus = MatchingStatus.COMPLETE;
         this.locationSelectionType = locationSelectionType;
         this.writer = writer;
         this.team = team;

--- a/core/src/main/java/com/wemingle/core/domain/post/entity/MatchingPostArea.java
+++ b/core/src/main/java/com/wemingle/core/domain/post/entity/MatchingPostArea.java
@@ -1,6 +1,5 @@
 package com.wemingle.core.domain.post.entity;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.wemingle.core.domain.post.entity.area.AreaName;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
@@ -23,7 +22,6 @@ public class MatchingPostArea {
     @Column(name = "AREA_NAME")
     private AreaName areaName; // 지역시 이름
 
-    @JsonIgnore
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "MATCHING_POST")

--- a/core/src/main/java/com/wemingle/core/domain/post/entity/matchingstatus/MatchingStatus.java
+++ b/core/src/main/java/com/wemingle/core/domain/post/entity/matchingstatus/MatchingStatus.java
@@ -1,5 +1,5 @@
 package com.wemingle.core.domain.post.entity.matchingstatus;
 
 public enum MatchingStatus {
-    PENDING, CANCEL, CANCEL_AFTER_, COMPLETE_BEFORE_REVIEW, COMPLETE
+    PENDING, CANCEL, COMPLETE
 }

--- a/core/src/main/java/com/wemingle/core/domain/post/repository/DSLMatchingPostRepository.java
+++ b/core/src/main/java/com/wemingle/core/domain/post/repository/DSLMatchingPostRepository.java
@@ -1,5 +1,6 @@
 package com.wemingle.core.domain.post.repository;
 
+import com.wemingle.core.domain.member.entity.Member;
 import com.wemingle.core.domain.post.entity.MatchingPost;
 import com.wemingle.core.domain.post.entity.abillity.Ability;
 import com.wemingle.core.domain.post.entity.area.AreaName;
@@ -14,6 +15,6 @@ import java.util.List;
 public interface DSLMatchingPostRepository {
 
     List<MatchingPost> findFilteredMatchingPost(Long nextIdx, RecruitmentType recruitmentType, Ability ability, Gender gender, RecruiterType recruiterType, List<AreaName> areaList, LocalDate currentDate, LocalDate dateFilter, Pageable pageable);
-    List<MatchingPost> findFilteredMatchingPostInMatchingFeed(Long nextIdx, RecruiterType recruiterType, boolean completeMatchesFilter, Pageable pageable);
+    List<MatchingPost> findCompletedMatchingPosts(Long nextIdx, RecruiterType recruiterType, boolean excludeCompleteMatchesFilter, Member member, List<MatchingPost> matchingPostWithReview, Pageable pageable);
 
 }

--- a/core/src/main/java/com/wemingle/core/domain/post/repository/DSLMatchingPostRepositoryImpl.java
+++ b/core/src/main/java/com/wemingle/core/domain/post/repository/DSLMatchingPostRepositoryImpl.java
@@ -121,8 +121,5 @@ public class DSLMatchingPostRepositoryImpl implements DSLMatchingPostRepository{
 
     private BooleanExpression allCompleteMatches(){
         return matchingPost.matchingStatus.ne(MatchingStatus.PENDING);
-        /*return matchingPost.matchingStatus.eq(MatchingStatus.COMPLETE)
-                .or(matchingPost.matchingStatus.eq(MatchingStatus.CANCEL))
-                .or((matchingPost.matchingDate.after(LocalDate.now()).and(matchingPost.matchingStatus.eq(MatchingStatus.PENDING))));*/
     }
 }

--- a/core/src/main/java/com/wemingle/core/domain/post/repository/DSLMatchingPostRepositoryImpl.java
+++ b/core/src/main/java/com/wemingle/core/domain/post/repository/DSLMatchingPostRepositoryImpl.java
@@ -2,10 +2,12 @@ package com.wemingle.core.domain.post.repository;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wemingle.core.domain.member.entity.Member;
 import com.wemingle.core.domain.post.entity.MatchingPost;
 import com.wemingle.core.domain.post.entity.abillity.Ability;
 import com.wemingle.core.domain.post.entity.area.AreaName;
 import com.wemingle.core.domain.post.entity.gender.Gender;
+import com.wemingle.core.domain.post.entity.matchingstatus.MatchingStatus;
 import com.wemingle.core.domain.post.entity.recruitertype.RecruiterType;
 import com.wemingle.core.domain.team.entity.recruitmenttype.RecruitmentType;
 import lombok.RequiredArgsConstructor;
@@ -84,15 +86,43 @@ public class DSLMatchingPostRepositoryImpl implements DSLMatchingPostRepository{
     }
 
     @Override
-    public List<MatchingPost> findFilteredMatchingPostInMatchingFeed(Long nextIdx, RecruiterType recruiterType, boolean completeMatchesFilter, Pageable pageable) {
+    public List<MatchingPost> findCompletedMatchingPosts(Long nextIdx, RecruiterType recruiterType, boolean excludeCompleteMatchesFilter, Member member, List<MatchingPost> matchingPostWithReview, Pageable pageable) {
         return jpaQueryFactory.selectFrom(matchingPost)
-                .join(matchingPost.team)
-//                .where(matchingPost.team)
+                .where(isTeamMemberInTeam(member))
                 .where(nextIdxLt(nextIdx))
                 .where(recruiterTypeEq(recruiterType))
+                .where(expiredMatchesFilter(excludeCompleteMatchesFilter, matchingPostWithReview))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
-                .orderBy(matchingPost.pk.desc())
+                .orderBy(matchingPost.createdTime.desc())
                 .fetch();
+    }
+
+    private BooleanExpression isTeamMemberInTeam(Member member){
+        return matchingPost.team.teamMembers.any().member.in(member);
+    }
+
+    private BooleanExpression expiredMatchesFilter(boolean excludeExpiredMatchesFilter, List<MatchingPost> matchingPostsWithReview){
+        return excludeExpiredMatchesFilter
+                ? isNotExpiredCompleteMatches(matchingPostsWithReview)
+                : allCompleteMatches();
+    }
+
+    private BooleanExpression isNotExpiredCompleteMatches(List<MatchingPost> matchingPostsWithReview) {
+        return matchingPostsWithReview.isEmpty()
+                ? (matchingPost.matchingDate.after(LocalDate.now()).and(matchingPost.matchingStatus.ne(MatchingStatus.PENDING)))
+                    .or(matchingPost.matchingDate.before(LocalDate.now()).and(matchingPost.matchingStatus.eq(MatchingStatus.COMPLETE)))
+                : matchingPost.notIn(matchingPostsWithReview)
+                    .and(
+                            ((matchingPost.matchingStatus.ne(MatchingStatus.PENDING)).and(matchingPost.matchingDate.after(LocalDate.now())))
+                            .or(matchingPost.matchingStatus.eq(MatchingStatus.COMPLETE).and(matchingPost.matchingDate.before(LocalDate.now())))
+                    );
+    }
+
+    private BooleanExpression allCompleteMatches(){
+        return matchingPost.matchingStatus.ne(MatchingStatus.PENDING);
+        /*return matchingPost.matchingStatus.eq(MatchingStatus.COMPLETE)
+                .or(matchingPost.matchingStatus.eq(MatchingStatus.CANCEL))
+                .or((matchingPost.matchingDate.after(LocalDate.now()).and(matchingPost.matchingStatus.eq(MatchingStatus.PENDING))));*/
     }
 }

--- a/core/src/main/java/com/wemingle/core/domain/post/repository/MatchingPostAreaRepository.java
+++ b/core/src/main/java/com/wemingle/core/domain/post/repository/MatchingPostAreaRepository.java
@@ -1,7 +1,11 @@
 package com.wemingle.core.domain.post.repository;
 
+import com.wemingle.core.domain.post.entity.MatchingPost;
 import com.wemingle.core.domain.post.entity.MatchingPostArea;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MatchingPostAreaRepository extends JpaRepository<MatchingPostArea,Long> {
+    List<MatchingPostArea> findByMatchingPostIn(List<MatchingPost> matchingPosts);
 }

--- a/core/src/main/java/com/wemingle/core/domain/post/service/MatchingPostService.java
+++ b/core/src/main/java/com/wemingle/core/domain/post/service/MatchingPostService.java
@@ -9,32 +9,39 @@ import com.wemingle.core.domain.member.entity.Member;
 import com.wemingle.core.domain.member.repository.MemberRepository;
 import com.wemingle.core.domain.post.dto.MatchingPostDto;
 import com.wemingle.core.domain.post.entity.MatchingPost;
+import com.wemingle.core.domain.post.entity.MatchingPostArea;
 import com.wemingle.core.domain.post.entity.abillity.Ability;
 import com.wemingle.core.domain.post.entity.area.AreaName;
 import com.wemingle.core.domain.post.entity.gender.Gender;
+import com.wemingle.core.domain.post.entity.matchingstatus.MatchingStatus;
 import com.wemingle.core.domain.post.entity.recruitertype.RecruiterType;
+import com.wemingle.core.domain.post.repository.MatchingPostAreaRepository;
 import com.wemingle.core.domain.post.repository.MatchingPostRepository;
+import com.wemingle.core.domain.review.repository.TeamReviewRepository;
 import com.wemingle.core.domain.team.entity.Team;
 import com.wemingle.core.domain.team.entity.TeamMember;
 import com.wemingle.core.domain.team.entity.recruitmenttype.RecruitmentType;
+import com.wemingle.core.domain.team.entity.teamtype.TeamType;
 import com.wemingle.core.domain.team.repository.TeamMemberRepository;
 import com.wemingle.core.domain.team.repository.TeamRepository;
 import com.wemingle.core.global.exceptionmessage.ExceptionMessage;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-import static com.wemingle.core.global.exceptionmessage.ExceptionMessage.TEAM_MEMBER_NOT_FOUND;
-import static com.wemingle.core.global.exceptionmessage.ExceptionMessage.TEAM_NOT_FOUND;
+import static com.wemingle.core.global.exceptionmessage.ExceptionMessage.*;
+import static com.wemingle.core.global.matchingstatusdescription.MatchingStatusDescription.*;
 
 @Slf4j
 @Service
@@ -42,12 +49,19 @@ import static com.wemingle.core.global.exceptionmessage.ExceptionMessage.TEAM_NO
 @Transactional(readOnly = true)
 public class MatchingPostService {
     private final MatchingPostRepository matchingPostRepository;
+    private final MatchingPostAreaRepository matchingPostAreaRepository;
     private final TeamRepository teamRepository;
     private final TeamMemberRepository teamMemberRepository;
     private final MemberRepository memberRepository;
     private final MatchingRepository matchingRepository;
     private final BookmarkRepository bookmarkRepository;
+    private final TeamReviewRepository teamReviewRepository;
     private final S3ImgService s3ImgService;
+
+    @Value("${wemingle.ip}")
+    private String serverIp;
+
+    private static final int PERMIT_CANCEL_DURATION = 3;
 
     public MatchingPost getMatchingPostByPostId(Long postId) {
         return matchingPostRepository.findById(postId)
@@ -101,8 +115,109 @@ public class MatchingPostService {
         return objectNode;
     }
 
-    public void getFilteredMatchingPostInMatchingFeed(Long nextIdx, RecruiterType recruiterType){
+    public LinkedHashMap<Long, MatchingPostDto.ResponseCompletedMatchingPost> getCompletedMatchingPosts(Long nextIdx, RecruiterType recruiterType, boolean excludeCompleteMatchesFilter, String memberId){
+        Member member = memberRepository.findByMemberId(memberId).orElseThrow(() -> new EntityNotFoundException(MEMBER_NOT_FOUNT.getExceptionMessage()));
+        List<MatchingPost> matchingPostWithMemberId = teamReviewRepository.findMatchingPostWithMemberId(member);
+        PageRequest pageRequest = PageRequest.of(0, 30);
 
+        List<MatchingPost> matchingPosts = matchingPostRepository.findCompletedMatchingPosts(nextIdx, recruiterType, excludeCompleteMatchesFilter, member, matchingPostWithMemberId, pageRequest);
+
+        List<MatchingPostArea> matchingPostAreas = matchingPostAreaRepository.findByMatchingPostIn(matchingPosts);
+
+        LinkedHashMap<Long, MatchingPostDto.ResponseCompletedMatchingPost> responseHashMap = new LinkedHashMap<>();
+
+        matchingPosts.forEach(matchingPost -> responseHashMap.put(matchingPost.getPk(), MatchingPostDto.ResponseCompletedMatchingPost.builder()
+                .matchingDate(matchingPost.getMatchingDate())
+                .recruiterType(matchingPost.getRecruiterType())
+                .teamName(matchingPost.getTeam().getTeamName())
+                .completedMatchingCnt(matchingPost.getTeam().getCompletedMatchingCnt())
+                .content(matchingPost.getContent())
+                .areaNames(getAreaNames(matchingPost, matchingPostAreas))
+                .isLocationConsensusPossible(matchingPost.isLocationConsensusPossible())
+                .ability(matchingPost.getAbility())
+                .profileImgUrl(getProfileImgUrl(matchingPost))
+                .detailPostUrl(serverIp + DETAIL_POST_URL.getRequestUrl() + matchingPost.getPk())
+                .matchingStatus(matchingStatusFactory(matchingPost.getMatchingStatus(), matchingPost.getMatchingDate()))
+                .scheduledRequest(getScheduledRequest(matchingPost, member, matchingPostWithMemberId))
+                .build()));
+
+        return responseHashMap;
+    }
+
+    private static List<AreaName> getAreaNames(MatchingPost matchingPost, List<MatchingPostArea> matchingPostAreas) {
+        return matchingPostAreas.stream()
+                .filter(matchingPostArea -> matchingPostArea.getMatchingPost().equals(matchingPost))
+                .map(MatchingPostArea::getAreaName)
+                .toList();
+    }
+
+    private String getProfileImgUrl(MatchingPost matchingPost) {
+        return isTeam(matchingPost)
+                ? s3ImgService.getGroupProfilePicUrl(matchingPost.getTeam().getProfileImgId())
+                : s3ImgService.getMemberProfilePicUrl(matchingPost.getTeam().getProfileImgId());
+    }
+
+    private static boolean isTeam(MatchingPost matchingPost) {
+        return matchingPost.getTeam().getTeamType().equals(TeamType.TEAM);
+    }
+
+    private String matchingStatusFactory(MatchingStatus matchingStatus, LocalDate matchingDate) {
+        switch (matchingStatus){
+            case CANCEL -> {
+                return CANCEL_MATCHING.getDescription();
+            }
+            case COMPLETE -> {
+                long remainDays = Duration.between(LocalDate.now().atStartOfDay(), matchingDate.atStartOfDay()).toDays();
+                return remainDays > 0 ? REMAIN_DAYS_PREFIX.getDescription() + remainDays : COMPLETE_MATCHING.getDescription();
+            }
+            default -> throw new RuntimeException(INVALID_MATCHING_POST_STATUS.getExceptionMessage());
+        }
+    }
+
+    private MatchingPostDto.ScheduledRequest getScheduledRequest(MatchingPost matchingPost, Member member, List<MatchingPost> matchingPostWithMemberId) {
+        return isTeamOwner(matchingPost, member)
+                ? scheduledRequestFactoryWithOwner(matchingPost.getMatchingStatus(), matchingPost.getMatchingDate(), matchingPost, matchingPostWithMemberId)
+                : scheduledRequestFactoryWithOwner();
+    }
+
+    private static boolean isTeamOwner(MatchingPost matchingPost, Member member) {
+        return matchingPost.getTeam().getTeamOwner().equals(member);
+    }
+
+    private MatchingPostDto.ScheduledRequest scheduledRequestFactoryWithOwner(MatchingStatus matchingStatus,
+                                                                              LocalDate matchingDate,
+                                                                              MatchingPost matchingPost,
+                                                                              List<MatchingPost> matchingPostWithMemberId) {
+        switch (matchingStatus) {
+            case CANCEL -> {
+                return new MatchingPostDto.ScheduledRequest(RENEW_MATCHING_POST.getDescription(), serverIp + RENEW_MATCHING_POST.getRequestUrl());
+            }
+            case COMPLETE -> {
+                long remainDays = Duration.between(LocalDate.now().atStartOfDay(), matchingDate.atStartOfDay()).toDays();
+
+                if (remainDays >= PERMIT_CANCEL_DURATION) {
+                    //todo 채팅 기능 구현되면 requestUrl 변경하기
+                    return new MatchingPostDto.ScheduledRequest(CANCEL_BY_CHAT.getDescription(), CANCEL_BY_CHAT.getRequestUrl());
+                } else if (remainDays >= 0) {
+                    return new MatchingPostDto.ScheduledRequest(CANCEL_NOT_PERMITTED_DURATION.getDescription(), CANCEL_NOT_PERMITTED_DURATION.getRequestUrl());
+                } else {
+                    return checkReviewWrittenPost(matchingPost, matchingPostWithMemberId);
+                }
+            }
+            default -> throw new RuntimeException(INVALID_MATCHING_POST_STATUS.getExceptionMessage());
+        }
+    }
+
+    private static MatchingPostDto.ScheduledRequest checkReviewWrittenPost(MatchingPost matchingPost, List<MatchingPost> matchingPostWithMemberId) {
+        if (matchingPostWithMemberId.contains(matchingPost)) {
+            return new MatchingPostDto.ScheduledRequest(AFTER_WRITE_REVIEW.getDescription(), AFTER_WRITE_REVIEW.getRequestUrl());
+        } else {
+            return new MatchingPostDto.ScheduledRequest(BEFORE_WRITE_REVIEW.getDescription(), BEFORE_WRITE_REVIEW.getRequestUrl());
+        }
+    }
+
+    private MatchingPostDto.ScheduledRequest scheduledRequestFactoryWithOwner() {
+        return new MatchingPostDto.ScheduledRequest(NO_PERMISSION.getDescription(), NO_PERMISSION.getRequestUrl());
     }
 
     @Transactional

--- a/core/src/main/java/com/wemingle/core/domain/post/service/MatchingPostService.java
+++ b/core/src/main/java/com/wemingle/core/domain/post/service/MatchingPostService.java
@@ -177,7 +177,7 @@ public class MatchingPostService {
     private MatchingPostDto.ScheduledRequest getScheduledRequest(MatchingPost matchingPost, Member member, List<MatchingPost> matchingPostWithMemberId) {
         return isTeamOwner(matchingPost, member)
                 ? scheduledRequestFactoryWithOwner(matchingPost.getMatchingStatus(), matchingPost.getMatchingDate(), matchingPost, matchingPostWithMemberId)
-                : scheduledRequestFactoryWithOwner();
+                : scheduledRequestFactoryWithMember();
     }
 
     private static boolean isTeamOwner(MatchingPost matchingPost, Member member) {
@@ -216,7 +216,7 @@ public class MatchingPostService {
         }
     }
 
-    private MatchingPostDto.ScheduledRequest scheduledRequestFactoryWithOwner() {
+    private MatchingPostDto.ScheduledRequest scheduledRequestFactoryWithMember() {
         return new MatchingPostDto.ScheduledRequest(NO_PERMISSION.getDescription(), NO_PERMISSION.getRequestUrl());
     }
 

--- a/core/src/main/java/com/wemingle/core/domain/review/entity/TeamReview.java
+++ b/core/src/main/java/com/wemingle/core/domain/review/entity/TeamReview.java
@@ -1,6 +1,7 @@
 package com.wemingle.core.domain.review.entity;
 
 import com.wemingle.core.domain.common.entity.BaseEntity;
+import com.wemingle.core.domain.post.entity.MatchingPost;
 import com.wemingle.core.domain.team.entity.Team;
 import com.wemingle.core.domain.member.entity.Member;
 import jakarta.persistence.*;
@@ -19,6 +20,11 @@ public class TeamReview extends BaseEntity {
     @NotNull
     @Column(name = "RATING")
     private int rating;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "MATCHING_POST")
+    private MatchingPost matchingPost;
 
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY)

--- a/core/src/main/java/com/wemingle/core/domain/review/repository/TeamReviewRepository.java
+++ b/core/src/main/java/com/wemingle/core/domain/review/repository/TeamReviewRepository.java
@@ -1,0 +1,15 @@
+package com.wemingle.core.domain.review.repository;
+
+import com.wemingle.core.domain.member.entity.Member;
+import com.wemingle.core.domain.post.entity.MatchingPost;
+import com.wemingle.core.domain.review.entity.TeamReview;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface TeamReviewRepository extends JpaRepository<TeamReview, Long> {
+    @Query("select tr.matchingPost from TeamReview tr where tr.reviewer = :member")
+    List<MatchingPost> findMatchingPostWithMemberId(@Param("member") Member member);
+}

--- a/core/src/main/java/com/wemingle/core/domain/review/service/TeamReviewService.java
+++ b/core/src/main/java/com/wemingle/core/domain/review/service/TeamReviewService.java
@@ -1,0 +1,10 @@
+package com.wemingle.core.domain.review.service;
+
+import com.wemingle.core.domain.member.entity.Member;
+import com.wemingle.core.domain.post.entity.MatchingPost;
+
+import java.util.List;
+
+public interface TeamReviewService {
+    List<MatchingPost> getMatchingPostsWithReviews(Member member);
+}

--- a/core/src/main/java/com/wemingle/core/domain/review/service/TeamReviewServiceImpl.java
+++ b/core/src/main/java/com/wemingle/core/domain/review/service/TeamReviewServiceImpl.java
@@ -1,0 +1,21 @@
+package com.wemingle.core.domain.review.service;
+
+import com.wemingle.core.domain.member.entity.Member;
+import com.wemingle.core.domain.post.entity.MatchingPost;
+import com.wemingle.core.domain.review.repository.TeamReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TeamReviewServiceImpl implements TeamReviewService{
+    private final TeamReviewRepository teamReviewRepository;
+    @Override
+    public List<MatchingPost> getMatchingPostsWithReviews(Member member) {
+        return teamReviewRepository.findMatchingPostWithMemberId(member);
+    }
+}

--- a/core/src/main/java/com/wemingle/core/domain/team/entity/Team.java
+++ b/core/src/main/java/com/wemingle/core/domain/team/entity/Team.java
@@ -3,6 +3,7 @@ package com.wemingle.core.domain.team.entity;
 import com.wemingle.core.domain.category.sports.entity.SportsCategory;
 import com.wemingle.core.domain.common.entity.BaseEntity;
 import com.wemingle.core.domain.member.entity.Member;
+import com.wemingle.core.domain.team.entity.teamtype.TeamType;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -38,6 +39,10 @@ public class Team extends BaseEntity {
     private UUID profileImgId;
 
     @NotNull
+    @Enumerated(EnumType.STRING)
+    private TeamType teamType;
+
+    @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "TEAM_OWNER")
     private Member teamOwner;
@@ -52,11 +57,12 @@ public class Team extends BaseEntity {
     private SportsCategory sportsCategory;
 
     @Builder
-    public Team(String teamName, int capacityLimit, UUID profileImgId, Member teamOwner, SportsCategory sportsCategory) {
+    public Team(String teamName, int capacityLimit, UUID profileImgId, TeamType teamType, Member teamOwner, SportsCategory sportsCategory) {
         this.teamName = teamName;
         this.capacityLimit = capacityLimit;
         this.completedMatchingCnt = 0;
         this.profileImgId = profileImgId;
+        this.teamType = teamType;
         this.teamOwner = teamOwner;
         this.sportsCategory = sportsCategory;
     }

--- a/core/src/main/java/com/wemingle/core/domain/team/entity/teamtype/TeamType.java
+++ b/core/src/main/java/com/wemingle/core/domain/team/entity/teamtype/TeamType.java
@@ -1,0 +1,5 @@
+package com.wemingle.core.domain.team.entity.teamtype;
+
+public enum TeamType {
+    INDIVIDUAL, TEAM
+}

--- a/core/src/main/java/com/wemingle/core/global/exceptionmessage/ExceptionMessage.java
+++ b/core/src/main/java/com/wemingle/core/global/exceptionmessage/ExceptionMessage.java
@@ -15,7 +15,6 @@ public enum ExceptionMessage {
     UNAVAILABLE_EMAIL("이미 가입된 이메일입니다"),
     IS_EXPIRED_REFRESH_AND_ACCESS_TOKEN("Refresh와 Access Token이 만료되었습니다. 사용자 인증을 다시해주세요"),
     UNREGISTERED_MEMBER("가입되지 않은 사용자입니다."),
-    UNSUPPORTED_EXTENSION("지원하지 않는 확장자입니다."),
-    CANNOT_SAVE_IMG("사진을 저장못했습니다.");
+    INVALID_MATCHING_POST_STATUS("유효하지 않은 매칭 글 상태입니다");
     private final String exceptionMessage;
 }

--- a/core/src/main/java/com/wemingle/core/global/initdb/InitDatabase.java
+++ b/core/src/main/java/com/wemingle/core/global/initdb/InitDatabase.java
@@ -24,6 +24,7 @@ import com.wemingle.core.domain.team.entity.Team;
 import com.wemingle.core.domain.team.entity.TeamMember;
 import com.wemingle.core.domain.team.entity.recruitmenttype.RecruitmentType;
 import com.wemingle.core.domain.team.entity.teamrole.TeamRole;
+import com.wemingle.core.domain.team.entity.teamtype.TeamType;
 import com.wemingle.core.domain.team.repository.TeamMemberRepository;
 import com.wemingle.core.domain.team.repository.TeamRepository;
 import jakarta.annotation.PostConstruct;
@@ -43,7 +44,7 @@ import java.util.List;
 import java.util.UUID;
 
 @Slf4j
-@Profile("howang")
+@Profile("jungwoo")
 @Component
 public class InitDatabase {
 
@@ -116,6 +117,7 @@ public class InitDatabase {
                     .capacityLimit(100)
                     .profileImgId(UUID.randomUUID())
                     .teamOwner(memberList.get(i))
+                    .teamType(TeamType.TEAM)
                     .sportsCategory(createSportsCategory())
                     .build();
 
@@ -132,8 +134,8 @@ public class InitDatabase {
         ArrayList<MatchingPost> matchingPosts = new ArrayList<>();
         for (int i = 0; i < amount; i++) {
             matchingPosts.add(MatchingPost.builder()
-                    .matchingDate(LocalDate.now())
-                    .expiryDate(LocalDate.of(2023, 3, 29))
+                    .matchingDate(LocalDate.of(2024, 3, 29))
+                    .expiryDate(LocalDate.of(2024, 3, 29))
                     .locationName("jacob house")
                     .position(point)
                     .content("msg")
@@ -147,7 +149,6 @@ public class InitDatabase {
                     .writer(memberList.get(i))
                     .team(teams.get(i))
                     .build());
-
         }
         return matchingPosts;
     }

--- a/core/src/main/java/com/wemingle/core/global/matchingstatusdescription/MatchingStatusDescription.java
+++ b/core/src/main/java/com/wemingle/core/global/matchingstatusdescription/MatchingStatusDescription.java
@@ -1,0 +1,26 @@
+package com.wemingle.core.global.matchingstatusdescription;
+
+import lombok.Getter;
+
+@Getter
+public enum MatchingStatusDescription {
+    DETAIL_POST_URL("매칭글 상세보기", "/post/match/"),
+    CANCEL_MATCHING("취소된 매칭", ""),
+    COMPLETE_MATCHING("매칭 완료", ""),
+    REMAIN_DAYS_PREFIX("D-", ""),
+    RENEW_MATCHING_POST("매칭글 다시 올리기", "/post/match"),
+    CANCEL_NOT_PERMITTED_DURATION("취소할 수 있는 기간이 아닙니다", ""),
+    CANCEL_BY_CHAT("채팅으로 신청 취소하기", "Dummy"),
+    //todo 채팅 기능 구현되면 requestUrl 변경하기
+    BEFORE_WRITE_REVIEW("매칭 일지 작성", ""),
+    AFTER_WRITE_REVIEW("매칭 일지 작성 완료", ""),
+    NO_PERMISSION("권한이 없습니다", "");
+
+    private final String description;
+    private final String requestUrl;
+
+    MatchingStatusDescription(String description, String requestUrl) {
+        this.description = description;
+        this.requestUrl = requestUrl;
+    }
+}

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -21,8 +21,6 @@ cloud:
 ##common setting
 spring:
   jpa:
-    hibernate:
-      ddl-auto: create
     defer-datasource-initialization: true
 
   mail:
@@ -41,6 +39,9 @@ spring:
   sql:
     init:
       mode: always
+
+wemingle:
+  ip: ENC(Xtb3qSACnMuBfHLCacz17TL1GTEQbFINe4khOzj2NU8WOEVgSU/i9g==)
 
 ---
 ## prod setting
@@ -94,7 +95,6 @@ logging:
         type:
           descriptor:
             sql: trace
-출처: https://haenny.tistory.com/379 [Haenny:티스토리]
 
 ---
 
@@ -115,3 +115,6 @@ spring:
       ddl-auto: create
     database: mysql
     database-platform: org.hibernate.dialect.MySQL8Dialect
+    properties:
+      hibernate:
+        default_batch_fetch_size: 1000


### PR DESCRIPTION
# **Pull request**

# Related issue

close # (issue)

---

## Type of change


- [x] New feature
- [ ] Refactor
- [ ] Bug fix
- [ ] Chore
- [ ] Style
- [ ] Test

---

#  📝Description

1. Team에 개인팀인지 확인하는 컬럼 추가
2. Team Review에 MatchingPost와 단방향 manyToOne 매핑
3. application.yml에 default_batch_fetch_size: 1000 추가
4. 매칭 완료된 글 조회 api 구현
 > getCompletedMatchingPosts 메소드로 매칭 완료 제외 옵션인 excludeCompleteMatchesFilter만 필수고 나머지 파라미터는 선택입니다.
