### PR TITLE
Refactor/team role

### DIFF
--- a/core/src/main/java/com/wemingle/core/domain/matching/controller/MatchingRequestController.java
+++ b/core/src/main/java/com/wemingle/core/domain/matching/controller/MatchingRequestController.java
@@ -61,11 +61,4 @@ public class MatchingRequestController {
 
         return ResponseEntity.noContent().build();
     }
-
-    @DeleteMapping
-    public ResponseEntity<Object> deleteMatchingRequests(@RequestBody MatchingRequestDto.MatchingRequestDelete matchingRequestDelete){
-        matchingRequestService.deleteMatchingRequests(matchingRequestDelete);
-
-        return ResponseEntity.noContent().build();
-    }
 }

--- a/core/src/main/java/com/wemingle/core/domain/matching/entity/MatchingRequest.java
+++ b/core/src/main/java/com/wemingle/core/domain/matching/entity/MatchingRequest.java
@@ -23,6 +23,9 @@ public class MatchingRequest extends BaseEntity {
     @Column(name = "CONTENT", length = 3000)
     private String content;
 
+    @Enumerated(EnumType.STRING)
+    private RequestMemberType requestMemberType;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "TEAM")
     private Team team;
@@ -40,12 +43,13 @@ public class MatchingRequest extends BaseEntity {
     private MatchingStatus matchingRequestStatus;
 
     @Builder
-    public MatchingRequest(String content, Team team, Member member, MatchingPost matchingPost) {
+    public MatchingRequest(String content, RequestMemberType requestMemberType, Team team, Member member, MatchingPost matchingPost, MatchingStatus matchingRequestStatus) {
         this.content = content;
+        this.requestMemberType = requestMemberType;
         this.team = team;
         this.member = member;
         this.matchingPost = matchingPost;
-        this.matchingRequestStatus = MatchingStatus.PENDING;
+        this.matchingRequestStatus = matchingRequestStatus;
     }
 
     public void cancelRequest(){

--- a/core/src/main/java/com/wemingle/core/domain/matching/entity/RequestMemberType.java
+++ b/core/src/main/java/com/wemingle/core/domain/matching/entity/RequestMemberType.java
@@ -1,0 +1,5 @@
+package com.wemingle.core.domain.matching.entity;
+
+public enum RequestMemberType {
+    REQUESTER, PARTICIPANT
+}

--- a/core/src/main/java/com/wemingle/core/domain/matching/repository/DSLMatchingRequestRepository.java
+++ b/core/src/main/java/com/wemingle/core/domain/matching/repository/DSLMatchingRequestRepository.java
@@ -12,7 +12,6 @@ import java.util.List;
 public interface DSLMatchingRequestRepository {
     Integer findReceivedMatchingCnt(String memberId);
 
-    //matchingRequest 테이블에서 팀장의 매칭 요청 레코드만 조회합니다.
     List<MatchingRequest> findMatchingRequestHistories(Long nextIdx,
                                                        RequestType requestType,
                                                        RecruiterType recruiterType,

--- a/core/src/main/java/com/wemingle/core/domain/matching/repository/DSLMatchingRequestRepositoryImpl.java
+++ b/core/src/main/java/com/wemingle/core/domain/matching/repository/DSLMatchingRequestRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.wemingle.core.domain.matching.controller.requesttype.RequestType;
 import com.wemingle.core.domain.matching.entity.MatchingRequest;
+import com.wemingle.core.domain.matching.entity.RequestMemberType;
 import com.wemingle.core.domain.member.entity.Member;
 import com.wemingle.core.domain.post.entity.MatchingPost;
 import com.wemingle.core.domain.post.entity.matchingstatus.MatchingStatus;
@@ -103,8 +104,7 @@ public class DSLMatchingRequestRepositoryImpl implements DSLMatchingRequestRepos
             return null;
         }
 
-        return matchingRequest.matchingPost.in(myMatchingPosts)
-                .and(teamOwnerFilter());
+        return matchingRequest.matchingPost.in(myMatchingPosts).and(requesterFilter());
     }
 
     private BooleanExpression excludeCompleteMatchesFilter(boolean excludeCompleteMatchesFilter){
@@ -113,7 +113,7 @@ public class DSLMatchingRequestRepositoryImpl implements DSLMatchingRequestRepos
                 : null;
     }
 
-    private BooleanExpression teamOwnerFilter(){
-        return matchingRequest.member.eq(matchingRequest.team.teamOwner);
+    private BooleanExpression requesterFilter(){
+        return matchingRequest.requestMemberType.eq(RequestMemberType.REQUESTER);
     }
 }

--- a/core/src/main/java/com/wemingle/core/domain/matching/repository/MatchingRequestRepository.java
+++ b/core/src/main/java/com/wemingle/core/domain/matching/repository/MatchingRequestRepository.java
@@ -20,7 +20,7 @@ public interface MatchingRequestRepository extends JpaRepository<MatchingRequest
             "order by mr.pk desc")
     List<MatchingRequest> findIndividualRequests(@Param("matchingPost") MatchingPost matchingPost);
     @Query("select mr from MatchingRequest mr join fetch mr.team " +
-            "where mr.matchingPost = :matchingPost and mr.matchingPost.recruiterType = 'TEAM' and mr.team.teamOwner = mr.member and mr.matchingRequestStatus = 'PENDING' " +
+            "where mr.matchingPost = :matchingPost and mr.matchingPost.recruiterType = 'TEAM' and mr.requestMemberType = 'REQUESTER' and mr.matchingRequestStatus = 'PENDING' " +
             "order by mr.pk desc")
     List<MatchingRequest> findTeamRequestsIsOwner(@Param("matchingPost") MatchingPost matchingPost);
     List<MatchingRequest> findByPkIn(List<Long> matchingRequestsPk);

--- a/core/src/main/java/com/wemingle/core/domain/matching/service/MatchingRequestService.java
+++ b/core/src/main/java/com/wemingle/core/domain/matching/service/MatchingRequestService.java
@@ -6,6 +6,7 @@ import com.wemingle.core.domain.matching.dto.MatchingRequestDto;
 import com.wemingle.core.domain.matching.dto.requesttitlestatus.RequestTitleStatus;
 import com.wemingle.core.domain.matching.entity.Matching;
 import com.wemingle.core.domain.matching.entity.MatchingRequest;
+import com.wemingle.core.domain.matching.entity.RequestMemberType;
 import com.wemingle.core.domain.matching.repository.MatchingRepository;
 import com.wemingle.core.domain.matching.repository.MatchingRequestRepository;
 import com.wemingle.core.domain.matching.vo.TitleInfo;
@@ -95,7 +96,7 @@ public class MatchingRequestService {
                     return getTitleInfoWithRecruiterType(matchingRequest, teamName);
                 }
 
-                return getTitleInfoWithSender(matchingRequest, findMember, teamName);
+                return getTitleInfoWithSender(matchingRequest, teamName);
             }
             default -> throw new RuntimeException(ExceptionMessage.INVALID_MATCHING_REQUEST_STATUS.getExceptionMessage());
         }
@@ -107,8 +108,8 @@ public class MatchingRequestService {
                 : new TitleInfo(teamName + RECEIVE_SUFFIX, RequestTitleStatus.RECEIVE_BY_INDIVIDUAL);
     }
 
-    private static TitleInfo getTitleInfoWithSender(MatchingRequest matchingRequest, Member findMember, String teamName) {
-        return matchingRequest.getTeam().getTeamOwner().equals(findMember)
+    private static TitleInfo getTitleInfoWithSender(MatchingRequest matchingRequest, String teamName) {
+        return matchingRequest.getRequestMemberType().equals(RequestMemberType.REQUESTER)
                 ? new TitleInfo(teamName + IS_OWNER_SENT_SUFFIX, RequestTitleStatus.SENT_BY_ME)
                 : new TitleInfo(IS_PARTICIPANT_TITLE_PREFIX + teamName + IS_PARTICIPANT_SENT_SUFFIX, RequestTitleStatus.SENT_BY_OWNER);
     }

--- a/core/src/main/java/com/wemingle/core/domain/matching/service/MatchingRequestService.java
+++ b/core/src/main/java/com/wemingle/core/domain/matching/service/MatchingRequestService.java
@@ -200,12 +200,6 @@ public class MatchingRequestService {
         matchingRepository.saveAll(saveMatching);
     }
 
-    @Transactional
-    public void deleteMatchingRequests(MatchingRequestDto.MatchingRequestDelete matchingRequestDelete){
-        List<MatchingRequest> matchingAllRequests = getAllMatchingRequests(matchingRequestDelete.getMatchingRequests());
-
-        matchingRequestRepository.deleteAllInBatch(matchingAllRequests);
-    }
 
     private List<MatchingRequest> getAllMatchingRequests(List<Long> matchingRequestsPk) {
         List<MatchingRequest> matchingRequests = matchingRequestRepository.findByPkIn(matchingRequestsPk);

--- a/core/src/main/java/com/wemingle/core/domain/post/dto/MatchingPostDto.java
+++ b/core/src/main/java/com/wemingle/core/domain/post/dto/MatchingPostDto.java
@@ -180,12 +180,11 @@ public class MatchingPostDto {
         private boolean isLocationConsensusPossible;
         private Ability ability;
         private String profileImgUrl;
-        private String detailPostUrl;
         private String matchingStatus;
         private String scheduledRequestDescription;
 
         @Builder
-        public ResponseCompletedMatchingPost(LocalDate matchingDate, RecruiterType recruiterType, String teamName, int completedMatchingCnt, String content, List<AreaName> areaNames, boolean isLocationConsensusPossible, Ability ability, String profileImgUrl, String detailPostUrl, String matchingStatus, String scheduledRequestDescription) {
+        public ResponseCompletedMatchingPost(LocalDate matchingDate, RecruiterType recruiterType, String teamName, int completedMatchingCnt, String content, List<AreaName> areaNames, boolean isLocationConsensusPossible, Ability ability, String profileImgUrl, String matchingStatus, String scheduledRequestDescription) {
             this.matchingDate = matchingDate;
             this.recruiterType = recruiterType;
             this.teamName = teamName;
@@ -195,10 +194,8 @@ public class MatchingPostDto {
             this.isLocationConsensusPossible = isLocationConsensusPossible;
             this.ability = ability;
             this.profileImgUrl = profileImgUrl;
-            this.detailPostUrl = detailPostUrl;
             this.matchingStatus = matchingStatus;
             this.scheduledRequestDescription = scheduledRequestDescription;
         }
     }
-
 }

--- a/core/src/main/java/com/wemingle/core/domain/post/repository/DSLMatchingPostRepository.java
+++ b/core/src/main/java/com/wemingle/core/domain/post/repository/DSLMatchingPostRepository.java
@@ -19,6 +19,6 @@ public interface DSLMatchingPostRepository {
 
     List<MatchingPost> findFilteredMatchingPost(Long lastIdx, RecruitmentType recruitmentType, Ability ability, Gender gender, RecruiterType recruiterType, List<AreaName> areaList, LocalDate currentDate, LocalDate dateFilter, YearMonth monthFilter, SortOption sortOption, Long lastViewCnt, LocalDate lastExpiredDate, SportsType sportsType, Pageable pageable);
     Integer findFilteredMatchingPostCnt(RecruitmentType recruitmentType, Ability ability, Gender gender, RecruiterType recruiterType, List<AreaName> areaList, LocalDate currentDate, LocalDate dateFilter, YearMonth monthFilter, SportsType sportsType);
-    List<MatchingPost> findCompletedMatchingPosts(Long nextIdx, RecruiterType recruiterType, boolean excludeCompleteMatchesFilter, Member member, List<MatchingPost> matchingPostWithReview, Pageable pageable);
+    List<MatchingPost> findCompletedMatchingPosts(Long nextIdx, RecruiterType recruiterType, boolean excludeCompleteMatchesFilter, Member member, List<MatchingPost> matchingPostWithReview);
     List<MatchingPost> findMatchingPostInMap(double topLat, double bottomLat, double leftLon, double rightLon);
 }

--- a/core/src/main/java/com/wemingle/core/domain/post/repository/DSLMatchingPostRepositoryImpl.java
+++ b/core/src/main/java/com/wemingle/core/domain/post/repository/DSLMatchingPostRepositoryImpl.java
@@ -141,16 +141,21 @@ public class DSLMatchingPostRepositoryImpl implements DSLMatchingPostRepository{
     }
 
     @Override
-    public List<MatchingPost> findCompletedMatchingPosts(Long nextIdx, RecruiterType recruiterType, boolean excludeCompleteMatchesFilter, Member member, List<MatchingPost> matchingPostWithReview, Pageable pageable) {
+    public List<MatchingPost> findCompletedMatchingPosts(Long nextIdx, RecruiterType recruiterType, boolean excludeCompleteMatchesFilter, Member member, List<MatchingPost> matchingPostWithReview) {
         return jpaQueryFactory.selectFrom(matchingPost)
-                .where(isTeamMemberInTeam(member))
-                .where(lastIdxLt(nextIdx))
-                .where(recruiterTypeEq(recruiterType))
-                .where(expiredMatchesFilter(excludeCompleteMatchesFilter, matchingPostWithReview))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
+                .where(
+                        isTeamMemberInTeam(member),
+                        nextIdx(nextIdx),
+                        recruiterTypeEq(recruiterType),
+                        expiredMatchesFilter(excludeCompleteMatchesFilter, matchingPostWithReview)
+                )
+                .limit(30)
                 .orderBy(matchingPost.createdTime.desc())
                 .fetch();
+    }
+
+    private BooleanExpression nextIdx(Long nextIdx) {
+        return nextIdx == null ? null : matchingPost.pk.loe(nextIdx);
     }
 
     @Override

--- a/core/src/main/java/com/wemingle/core/domain/team/controller/TeamController.java
+++ b/core/src/main/java/com/wemingle/core/domain/team/controller/TeamController.java
@@ -21,7 +21,7 @@ public class TeamController {
     private final TeamService teamService;
     private final TeamMemberService teamMemberService;
 
-    @GetMapping("/post")
+    @GetMapping("/profile/writable")
     public ResponseEntity<ResponseHandler<HashMap<Long, TeamDto.ResponseTeamInfoDto>>> getTeamInfoByMemberId(@AuthenticationPrincipal UserDetails userDetails){
         HashMap<Long, TeamDto.ResponseTeamInfoDto> teamListInfo = teamService.getTeamInfoWithMemberId(userDetails.getUsername());
 

--- a/core/src/main/java/com/wemingle/core/domain/team/controller/TeamController.java
+++ b/core/src/main/java/com/wemingle/core/domain/team/controller/TeamController.java
@@ -23,7 +23,7 @@ public class TeamController {
 
     @GetMapping("/profile/writable")
     public ResponseEntity<ResponseHandler<HashMap<Long, TeamDto.ResponseTeamInfoDto>>> getTeamInfoByMemberId(@AuthenticationPrincipal UserDetails userDetails){
-        HashMap<Long, TeamDto.ResponseTeamInfoDto> teamListInfo = teamService.getTeamInfoWithMemberId(userDetails.getUsername());
+        HashMap<Long, TeamDto.ResponseTeamInfoDto> teamListInfo = teamService.getTeamInfoWithAvailableWrite(userDetails.getUsername());
 
         return ResponseEntity.ok(
                 ResponseHandler.<HashMap<Long, TeamDto.ResponseTeamInfoDto>>builder()

--- a/core/src/main/java/com/wemingle/core/domain/team/repository/TeamMemberRepository.java
+++ b/core/src/main/java/com/wemingle/core/domain/team/repository/TeamMemberRepository.java
@@ -19,4 +19,6 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     List<Team> findMyTeams(@Param("memberId") String memberId);
     @Query("select tm.team from TeamMember tm where tm.member.memberId = :memberId and tm.teamRole != 'PARTICIPANT'")
     List<Team> findTeamsWithAvailableWrite(@Param("memberId") String memberId);
+    @Query("select tm from TeamMember tm where tm.team in :teams and (tm.teamRole = 'OWNER' or tm.teamRole = 'MANAGER')")
+    List<TeamMember> findWithManagerOrHigher(@Param("teams") List<Team> teams);
 }

--- a/core/src/main/java/com/wemingle/core/domain/team/repository/TeamMemberRepository.java
+++ b/core/src/main/java/com/wemingle/core/domain/team/repository/TeamMemberRepository.java
@@ -17,4 +17,6 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     boolean existsByMember(Member member);
     @Query("select tm.team from TeamMember tm where tm.member.memberId = :memberId and tm.team.teamType = 'TEAM'")
     List<Team> findMyTeams(@Param("memberId") String memberId);
+    @Query("select tm.team from TeamMember tm where tm.member.memberId = :memberId and tm.teamRole != 'PARTICIPANT'")
+    List<Team> findTeamsWithAvailableWrite(@Param("memberId") String memberId);
 }

--- a/core/src/main/java/com/wemingle/core/domain/team/service/TeamService.java
+++ b/core/src/main/java/com/wemingle/core/domain/team/service/TeamService.java
@@ -6,7 +6,7 @@ import com.wemingle.core.domain.team.dto.TeamDto;
 import java.util.HashMap;
 
 public interface TeamService {
-    HashMap<Long, TeamDto.ResponseTeamInfoDto> getTeamInfoWithMemberId(String memberId);
+    HashMap<Long, TeamDto.ResponseTeamInfoDto> getTeamInfoWithAvailableWrite(String memberId);
     TeamDto.ResponseTeamHomeConditions getTeamHomeConditions(String memberId);
     HashMap<Long, TeamDto.ResponseRecommendationTeamInfo> getRecommendTeams(Long nextIdx, String memberId);
     HashMap<Long, TeamDto.ResponseRecommendationTeamForMemberInfo> getRecommendTeamsForMember(Long nextIdx, String memberId);

--- a/core/src/main/java/com/wemingle/core/domain/team/service/TeamServiceImpl.java
+++ b/core/src/main/java/com/wemingle/core/domain/team/service/TeamServiceImpl.java
@@ -45,7 +45,7 @@ public class TeamServiceImpl implements TeamService{
 
     private static final int PAGE_SIZE = 30;
     @Override
-    public HashMap<Long, TeamDto.ResponseTeamInfoDto> getTeamInfoWithMemberId(String memberId) {
+    public HashMap<Long, TeamDto.ResponseTeamInfoDto> getTeamInfoWithAvailableWrite(String memberId) {
         List<Team> teamList = teamMemberRepository.findTeamsWithAvailableWrite(memberId);
 
         HashMap<Long, TeamDto.ResponseTeamInfoDto> responseTeamInfo = new HashMap<>();

--- a/core/src/main/java/com/wemingle/core/domain/team/service/TeamServiceImpl.java
+++ b/core/src/main/java/com/wemingle/core/domain/team/service/TeamServiceImpl.java
@@ -46,7 +46,7 @@ public class TeamServiceImpl implements TeamService{
     private static final int PAGE_SIZE = 30;
     @Override
     public HashMap<Long, TeamDto.ResponseTeamInfoDto> getTeamInfoWithMemberId(String memberId) {
-        List<Team> teamList = teamRepository.findByTeamOwner_MemberId(memberId);
+        List<Team> teamList = teamMemberRepository.findTeamsWithAvailableWrite(memberId);
 
         HashMap<Long, TeamDto.ResponseTeamInfoDto> responseTeamInfo = new HashMap<>();
 

--- a/core/src/main/java/com/wemingle/core/global/initdb/InitDatabaseV2.java
+++ b/core/src/main/java/com/wemingle/core/global/initdb/InitDatabaseV2.java
@@ -1,0 +1,208 @@
+package com.wemingle.core.global.initdb;
+
+
+import com.wemingle.core.domain.bookmark.entity.BookmarkedMatchingPost;
+import com.wemingle.core.domain.bookmark.repository.BookmarkRepository;
+import com.wemingle.core.domain.category.sports.entity.sportstype.SportsType;
+import com.wemingle.core.domain.member.entity.Member;
+import com.wemingle.core.domain.member.entity.PolicyTerms;
+import com.wemingle.core.domain.member.entity.phonetype.PhoneType;
+import com.wemingle.core.domain.member.entity.role.Role;
+import com.wemingle.core.domain.member.entity.signupplatform.SignupPlatform;
+import com.wemingle.core.domain.member.repository.MemberRepository;
+import com.wemingle.core.domain.member.repository.PolicyTermsRepository;
+import com.wemingle.core.domain.post.entity.MatchingPost;
+import com.wemingle.core.domain.post.entity.MatchingPostArea;
+import com.wemingle.core.domain.post.entity.abillity.Ability;
+import com.wemingle.core.domain.post.entity.area.AreaName;
+import com.wemingle.core.domain.post.entity.gender.Gender;
+import com.wemingle.core.domain.post.entity.locationselectiontype.LocationSelectionType;
+import com.wemingle.core.domain.post.entity.recruitertype.RecruiterType;
+import com.wemingle.core.domain.post.repository.MatchingPostAreaRepository;
+import com.wemingle.core.domain.post.repository.MatchingPostRepository;
+import com.wemingle.core.domain.team.entity.Team;
+import com.wemingle.core.domain.team.entity.TeamMember;
+import com.wemingle.core.domain.team.entity.recruitmenttype.RecruitmentType;
+import com.wemingle.core.domain.team.entity.teamrole.TeamRole;
+import com.wemingle.core.domain.team.entity.teamtype.TeamType;
+import com.wemingle.core.domain.team.repository.TeamMemberRepository;
+import com.wemingle.core.domain.team.repository.TeamRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+@Slf4j
+@Profile("howang")
+@Component
+public class InitDatabaseV2 {
+
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    PolicyTermsRepository policyTermsRepository;
+    @Autowired
+    MatchingPostRepository matchingPostRepository;
+    @Autowired
+    TeamRepository teamRepository;
+    @Autowired
+    TeamMemberRepository teamMemberRepository;
+    @Autowired
+    MatchingPostAreaRepository matchingPostAreaRepository;
+    @Autowired
+    BookmarkRepository bookmarkRepository;
+
+    @PostConstruct
+    public void InitDatabase() throws NoSuchAlgorithmException, InvalidKeySpecException {
+        log.info("initinitV2");
+
+        createMember();
+        List<Member> memberRepositoryAll = memberRepository.findAll();
+        List<Team> teams = createTeam(memberRepositoryAll);
+        List<TeamMember> teamMembers = createTeamMember(memberRepositoryAll, teams);
+        for (int i = 0; i < 10; i++) {
+            teams.get(i).addTeamMember(teamMembers.get(i));
+        }
+        List<Team> teamList = teamRepository.saveAll(teams);
+        List<TeamMember> teamMemberRepositoryAll = teamMemberRepository.findAll();
+        ArrayList<MatchingPost> matchingPost = createMatchingPost(teamMemberRepositoryAll, teamList);
+        List<MatchingPostArea> matchingPostArea = createMatchingPostArea(matchingPost);
+        for (int i = 0; i < 10; i++) {
+            matchingPost.get(i).putArea(matchingPostArea.get(i));
+        }
+        List<MatchingPost> matchingPosts = matchingPostRepository.saveAll(matchingPost);
+
+        bookmarkRepository.saveAll(createBookmark(matchingPosts, memberRepositoryAll));
+
+    }
+
+    private List<BookmarkedMatchingPost> createBookmark(List<MatchingPost> matchingPosts, List<Member> members) {
+        List<BookmarkedMatchingPost> returnBookmark = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            BookmarkedMatchingPost bookmarkedMatchingPost = BookmarkedMatchingPost.builder()
+                    .matchingPost(matchingPosts.get(i))
+                    .member(members.get(i))
+                    .build();
+
+            returnBookmark.add(bookmarkedMatchingPost);
+        }
+
+        return returnBookmark;
+    }
+
+    private List<MatchingPostArea> createMatchingPostArea(ArrayList<MatchingPost> matchingPosts) {
+        return matchingPosts.stream().map(m -> MatchingPostArea.builder().areaName(AreaName.경기).matchingPost(m).build()).toList();
+    }
+
+    private List<TeamMember> createTeamMember(List<Member> memberList, List<Team> teams) {
+        List<TeamMember> returnTeamMembers = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            TeamMember teamMember = TeamMember.builder()
+                    .nickname("nickname" + i)
+                    .profileImg(UUID.randomUUID())
+                    .teamRole(TeamRole.PARTICIPANT)
+                    .member(memberList.get(i))
+                    .team(teams.get(i))
+                    .build();
+
+            returnTeamMembers.add(teamMember);
+        }
+
+        return returnTeamMembers;
+    }
+
+
+    private List<Team> createTeam(List<Member> memberList) {
+        List<Team> returnTeams = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            Team team = Team.builder()
+                    .teamName("teamname" + i)
+                    .capacityLimit(100)
+                    .profileImgId(UUID.randomUUID())
+                    .content("teamname" + i)
+                    .recruitmentType(RecruitmentType.FIRST_SERVED_BASED)
+                    .teamOwner(memberList.get(i))
+                    .teamType(TeamType.TEAM)
+                    .sportsCategory(SportsType.OTHER)
+                    .build();
+
+            returnTeams.add(team);
+        }
+
+        return returnTeams;
+    }
+
+    private ArrayList<MatchingPost> createMatchingPost(List<TeamMember> memberList, List<Team> teams) {
+        ArrayList<MatchingPost> matchingPosts = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            matchingPosts.add(MatchingPost.builder()
+                    .matchingDate(LocalDate.of(2024, 3, 29))
+                    .expiryDate(LocalDate.of(2024, new Random().nextInt(12)+1, new Random().nextInt(29)+1))
+                    .locationName("jacob house")
+                    .lat(new Random().nextDouble(90))
+                    .lon(new Random().nextDouble(180))
+                    .content("msg")
+                    .capacityLimit(10)
+                    .isLocationConsensusPossible(true)
+                    .ability(Ability.MEDIUM)
+                    .gender(Gender.MALE)
+                    .recruiterType(RecruiterType.INDIVIDUAL)
+                    .recruitmentType(RecruitmentType.APPROVAL_BASED)
+                    .locationSelectionType(LocationSelectionType.SELECT_BASED)
+                    .writer(memberList.get(i))
+                    .team(teams.get(i))
+                    .viewCnt(new Random().nextInt(100))//new Random().nextInt(100000)
+                    .sportsCategory(SportsType.OTHER)
+                    .build());
+        }
+        return matchingPosts;
+    }
+
+    private void createMember() {
+        for (int i = 0; i < 10 -1; i++) {
+            memberRepository.save(Member.builder()
+                    .memberId("memberId" + i)
+                    .gender(Gender.MALE)
+                    .majorActivityArea(AreaName.강원)
+                    .oneLineIntroduction("안녕")
+                    .password("password")
+                    .nickname("nickname" + i)
+                    .profileImgId(UUID.randomUUID())
+                    .phoneType(PhoneType.AOS)
+                    .signupPlatform(SignupPlatform.APPLE)
+                    .refreshToken("token")
+                    .firebaseToken("fire")
+                    .role(Role.USER)
+                    .notifyAllow(true)
+                    .policyTerms(policyTermsRepository.save(new PolicyTerms(true, true)))
+                    .build());
+        }
+        memberRepository.save(Member.builder()
+                .memberId("wemingle@gmail.com")
+                .gender(Gender.MALE)
+                .majorActivityArea(AreaName.강원)
+                .oneLineIntroduction("안녕")
+                .password("password")
+                .nickname("leeking")
+                .profileImgId(UUID.randomUUID())
+                .phoneType(PhoneType.AOS)
+                .signupPlatform(SignupPlatform.APPLE)
+                .refreshToken("token")
+                .firebaseToken("fire")
+                .role(Role.USER)
+                .notifyAllow(true)
+                .policyTerms(policyTermsRepository.save(new PolicyTerms(true, true)))
+                .build());
+    }
+
+
+}


### PR DESCRIPTION
# **Pull request**

# Related issue

close #124 

---

## Type of change


- [ ] New feature
- [x] Refactor
- [ ] Bug fix
- [ ] Chore
- [ ] Style
- [ ] Test

---

#  📝Description

팀에 owner말고 manager 권한 추가로 서비스 로직 수정

1. 승인 리스트에서 팀일 때 매칭 신청 조회 로직 수정
2. 매칭글 쓰기 전 팀 프로필 조회 로직에서 쓰기 권한이 있는 모든 팀 조회하도록 수정
3. 완료된 매칭글에서 권한 사용 부분 로직 수정
4. 매칭 히스토리 조회에서 팀당 하나의 신청만 조회하는 로직 수정
