### PR TITLE
feat<ImgController>: 팀 내 글의 이미지를 s3에 업로드할 수 있는 presigned url 발급

### DIFF
--- a/core/src/main/java/com/wemingle/core/domain/img/controller/ImgController.java
+++ b/core/src/main/java/com/wemingle/core/domain/img/controller/ImgController.java
@@ -4,16 +4,15 @@ import com.wemingle.core.domain.img.service.S3ImgService;
 import com.wemingle.core.domain.member.service.MemberService;
 import com.wemingle.core.domain.team.service.TeamService;
 import com.wemingle.core.global.responseform.ResponseHandler;
+import jakarta.validation.constraints.Max;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @Slf4j
@@ -49,6 +48,16 @@ public class ImgController {
         return ResponseEntity.ok(ResponseHandler.builder()
                 .responseMessage("s3 url issuance complete")
                 .responseData(groupProfilePreSignedUrl)
+                .build());
+    }
+
+    @GetMapping("/post/team/upload")
+    public ResponseEntity<ResponseHandler<Object>> getTeamPostPicUploadPreSignUrl(@RequestParam @Max(value = 5, message = "이미지는 최대 5장까지 업로드 가능합니다.") int imgCnt) {
+        List<String> teamPostPreSignedUrls = s3ImgService.setTeamPostPreSignedUrl(imgCnt);
+
+        return ResponseEntity.ok(ResponseHandler.builder()
+                .responseMessage("s3 url issuance complete")
+                .responseData(teamPostPreSignedUrls)
                 .build());
     }
 }

--- a/core/src/main/java/com/wemingle/core/domain/img/service/S3ImgService.java
+++ b/core/src/main/java/com/wemingle/core/domain/img/service/S3ImgService.java
@@ -67,4 +67,16 @@ public class S3ImgService {
         }
         return s3Urls;
     }
+
+    public List<String> setTeamPostPreSignedUrl(int imgCnt){
+        ArrayList<String> s3Urls = new ArrayList<>();
+        for (int i = 0; i < imgCnt; i++) {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder().bucket(bucket).key("post/team/" + UUID.randomUUID()).build();
+            PutObjectPresignRequest objectPresignRequest = PutObjectPresignRequest.builder().putObjectRequest(putObjectRequest).signatureDuration(Duration.ofMinutes(1)).build();
+            URL url = s3Presigner.presignPutObject(objectPresignRequest).url();
+            s3Urls.add(url.toString());
+            s3Presigner.close();
+        }
+        return s3Urls;
+    }
 }


### PR DESCRIPTION
# **Pull request**

# Related issue

close #148 

---

## Type of change


- [x] New feature
- [ ] Refactor
- [ ] Bug fix
- [ ] Chore
- [ ] Style
- [ ] Test

---

#  📝Description

팀 내 글의 이미지를 s3에 업로드할 수 있는 url 발급하는 api 구현
> 최대 5장의 이미지만 업로드 가능
