### PR TITLE
fix<MatchingPostDto>: jsonproperites 추가해서 is로 시작하는 boolean데이터 받도록 수정

### DIFF
--- a/core/src/main/java/com/wemingle/core/domain/post/dto/MatchingPostDto.java
+++ b/core/src/main/java/com/wemingle/core/domain/post/dto/MatchingPostDto.java
@@ -1,5 +1,6 @@
 package com.wemingle.core.domain.post.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.wemingle.core.domain.category.sports.entity.sportstype.SportsType;
 import com.wemingle.core.domain.post.entity.MatchingPost;
 import com.wemingle.core.domain.post.entity.MatchingPostArea;
@@ -146,6 +147,7 @@ public class MatchingPostDto {
         private String ri;
         private List<AreaName> areaNameList;
         @NotNull
+        @JsonProperty(value = "isLocationConsensusPossible")
         private boolean isLocationConsensusPossible;
         @NotNull
         private Ability ability;


### PR DESCRIPTION
# **Pull request**

# Related issue

close # (issue)

---

## Type of change


- [ ] New feature
- [x] Refactor
- [ ] Bug fix
- [ ] Chore
- [ ] Style
- [ ] Test

---

#  📝Description

매칭 글 생성할때 매칭 날짜의 데이터를 리스트로 받도록 수정
