### PR TITLE
fix<TeamPostService>: 팀 내의 글 조회에서 누락된 사진 링크 데이터 추가

### DIFF
--- a/core/src/main/java/com/wemingle/core/domain/post/dto/TeamPostDto.java
+++ b/core/src/main/java/com/wemingle/core/domain/post/dto/TeamPostDto.java
@@ -29,9 +29,10 @@ public class TeamPostDto {
         @JsonProperty(value = "isWriter")
         private boolean isWriter;
         private VoteInfo voteInfo;
+        private String imgUrl;
 
         @Builder
-        public ResponseTeamPostsInfoWithMember(String teamName, String title, String content, String nickname, LocalDateTime createdTime, List<String> teamPostImgUrls, int likeCnt, int replyCnt, boolean isBookmarked, boolean isWriter, VoteInfo voteInfo) {
+        public ResponseTeamPostsInfoWithMember(String teamName, String title, String content, String nickname, LocalDateTime createdTime, List<String> teamPostImgUrls, int likeCnt, int replyCnt, boolean isBookmarked, boolean isWriter, VoteInfo voteInfo, String imgUrl) {
             this.teamName = teamName;
             this.title = title;
             this.content = content;
@@ -43,6 +44,7 @@ public class TeamPostDto {
             this.isBookmarked = isBookmarked;
             this.isWriter = isWriter;
             this.voteInfo = voteInfo;
+            this.imgUrl = imgUrl;
         }
     }
 
@@ -107,9 +109,10 @@ public class TeamPostDto {
         @JsonProperty(value = "isWriter")
         private boolean isWriter;
         private VoteInfo voteInfo;
+        private String imgUrl;
 
         @Builder
-        public TeamPostInfo(String title, String content, String nickname, LocalDateTime createdTime, List<String> teamPostImgUrls, PostType postType, int likeCnt, int replyCnt, boolean isBookmarked, VoteInfo voteInfo, boolean isWriter) {
+        public TeamPostInfo(String title, String content, String nickname, LocalDateTime createdTime, List<String> teamPostImgUrls, PostType postType, int likeCnt, int replyCnt, boolean isBookmarked, boolean isWriter, VoteInfo voteInfo, String imgUrl) {
             this.title = title;
             this.content = content;
             this.nickname = nickname;
@@ -119,8 +122,9 @@ public class TeamPostDto {
             this.likeCnt = likeCnt;
             this.replyCnt = replyCnt;
             this.isBookmarked = isBookmarked;
-            this.voteInfo = voteInfo;
             this.isWriter = isWriter;
+            this.voteInfo = voteInfo;
+            this.imgUrl = imgUrl;
         }
     }
 
@@ -198,9 +202,10 @@ public class TeamPostDto {
         private boolean isBookmarked;
         @JsonProperty(value = "isWriter")
         private boolean isWriter;
+        private String imgUrl;
 
         @Builder
-        public ResponseSearchTeamPost(String title, String content, String writerName, LocalDateTime createTime, int likeCnt, int replyCnt, boolean isBookmarked, boolean isWriter) {
+        public ResponseSearchTeamPost(String title, String content, String writerName, LocalDateTime createTime, int likeCnt, int replyCnt, boolean isBookmarked, boolean isWriter, String imgUrl) {
             this.title = title;
             this.content = content;
             this.writerName = writerName;
@@ -209,6 +214,7 @@ public class TeamPostDto {
             this.replyCnt = replyCnt;
             this.isBookmarked = isBookmarked;
             this.isWriter = isWriter;
+            this.imgUrl = imgUrl;
         }
     }
 }

--- a/core/src/main/java/com/wemingle/core/domain/post/service/TeamPostService.java
+++ b/core/src/main/java/com/wemingle/core/domain/post/service/TeamPostService.java
@@ -91,6 +91,7 @@ public class TeamPostService {
                 .isWriter(isWriter(teamPost, member))
                 .isBookmarked(isBookmarked(teamPost, bookmarkedTeamPosts))
                 .voteInfo(getVoteInfo(teamPost.getTeamPostVote()))
+                .imgUrl(s3ImgService.getTeamMemberPreSignedUrl(teamPost.getWriter().getProfileImg()))
                 .build()
         ));
         return responseData;
@@ -122,6 +123,7 @@ public class TeamPostService {
                 .isWriter(isWriter(teamPost, teamMember))
                 .isBookmarked(isBookmarked(teamPost, bookmarkedTeamPosts))
                 .voteInfo(getVoteInfo(teamPost.getTeamPostVote()))
+                .imgUrl(s3ImgService.getTeamMemberPreSignedUrl(teamPost.getWriter().getProfileImg()))
                 .build()
         ));
 
@@ -234,16 +236,17 @@ public class TeamPostService {
         List<TeamPost> searchTeamPosts = teamPostRepository.getSearchTeamPost(nextIdx, team, searchWord);
         LinkedHashMap<Long, TeamPostDto.ResponseSearchTeamPost> responseData = new LinkedHashMap<>();
 
-        searchTeamPosts.forEach(teampost -> responseData.put(teampost.getPk(), TeamPostDto.ResponseSearchTeamPost
+        searchTeamPosts.forEach(teamPost -> responseData.put(teamPost.getPk(), TeamPostDto.ResponseSearchTeamPost
                 .builder()
-                .title(teampost.getTitle())
-                .content(teampost.getContent())
-                .writerName(teampost.getWriter().getNickname())
-                .createTime(teampost.getCreatedTime())
-                .likeCnt(teampost.getLikeCount())
-                .replyCnt(teampost.getReplyCount())
-                .isBookmarked(isBookmarked(teampost, myBookmarkedTeamPosts))
-                .isWriter(isWriter(teampost, member))
+                .title(teamPost.getTitle())
+                .content(teamPost.getContent())
+                .writerName(teamPost.getWriter().getNickname())
+                .createTime(teamPost.getCreatedTime())
+                .likeCnt(teamPost.getLikeCount())
+                .replyCnt(teamPost.getReplyCount())
+                .isBookmarked(isBookmarked(teamPost, myBookmarkedTeamPosts))
+                .isWriter(isWriter(teamPost, member))
+                .imgUrl(s3ImgService.getTeamMemberPreSignedUrl(teamPost.getWriter().getProfileImg()))
                 .build()));
 
         return responseData;


### PR DESCRIPTION
# **Pull request**

# Related issue

close #184 

---

## Type of change


- [ ] New feature
- [ ] Refactor
- [x] Bug fix
- [ ] Chore
- [ ] Style
- [ ] Test

---

#  📝Description

팀 내의 글 조회할때 누락된 작성자의 사진 링크 데이터 추가