### PR TITLE
refactor<TeamPostDto>: 팀 내의 글 조회할 때 투표의 제목, 마감일, 총 참가자 수 데이터 추가

### DIFF
--- a/core/src/main/java/com/wemingle/core/domain/post/dto/TeamPostDto.java
+++ b/core/src/main/java/com/wemingle/core/domain/post/dto/TeamPostDto.java
@@ -139,11 +139,17 @@ public class TeamPostDto {
     @NoArgsConstructor
     public static class VoteInfo{
         private Long votePk;
+        private String title;
+        private LocalDateTime expiryTime;
+        private int participantCnt;
         private List<VoteOptionInfo> voteOptionInfos;
 
         @Builder
-        public VoteInfo(Long votePk, List<VoteOptionInfo> voteOptionInfos) {
+        public VoteInfo(Long votePk, String title, LocalDateTime expiryTime, List<VoteOptionInfo> voteOptionInfos) {
             this.votePk = votePk;
+            this.title = title;
+            this.expiryTime = expiryTime;
+            this.participantCnt = voteOptionInfos.stream().mapToInt(VoteOptionInfo::getResultCnt).sum();
             this.voteOptionInfos = voteOptionInfos;
         }
     }
@@ -284,6 +290,9 @@ public class TeamPostDto {
     @NoArgsConstructor
     public static class VoteInfoWithPk{
         private Long votePk;
+        private String title;
+        private LocalDateTime expiryTime;
+        private int participantCnt;
         @JsonProperty(value = "isMultiVoting")
         private boolean isMultiVoting;
         @JsonProperty(value = "isComplete")
@@ -291,8 +300,11 @@ public class TeamPostDto {
         private List<VoteOptionInfoWithPk> voteOptionInfos;
 
         @Builder
-        public VoteInfoWithPk(Long votePk, boolean isMultiVoting, boolean isComplete, List<VoteOptionInfoWithPk> voteOptionInfos) {
+        public VoteInfoWithPk(Long votePk, String title, LocalDateTime expiryTime, boolean isMultiVoting, boolean isComplete, List<VoteOptionInfoWithPk> voteOptionInfos) {
             this.votePk = votePk;
+            this.title = title;
+            this.expiryTime = expiryTime;
+            this.participantCnt = voteOptionInfos.stream().mapToInt(VoteOptionInfoWithPk::getResultCnt).sum();
             this.isMultiVoting = isMultiVoting;
             this.isComplete = isComplete;
             this.voteOptionInfos = voteOptionInfos;

--- a/core/src/main/java/com/wemingle/core/domain/post/service/TeamPostService.java
+++ b/core/src/main/java/com/wemingle/core/domain/post/service/TeamPostService.java
@@ -62,6 +62,8 @@ public class TeamPostService {
                         .voteInfo(TeamPostDto.VoteInfo.builder()
                                 .votePk(teamPost.getTeamPostVote()
                                         .getPk())
+                                .title(teamPost.getTeamPostVote().getTitle())
+                                .expiryTime(teamPost.getTeamPostVote().getExpiryTime())
                                 .voteOptionInfos(teamPost.getTeamPostVote()
                                         .getVoteOptions().stream()
                                         .map(voteOption -> TeamPostDto.VoteOptionInfo.builder()
@@ -166,6 +168,8 @@ public class TeamPostService {
 
         return TeamPostDto.VoteInfo.builder()
                 .votePk(vote.getPk())
+                .title(vote.getTitle())
+                .expiryTime(vote.getExpiryTime())
                 .voteOptionInfos(vote.getVoteOptions().stream().map(voteOption -> TeamPostDto.VoteOptionInfo.builder()
                         .optionName(voteOption.getOptionName())
                         .resultCnt(voteOption.getVoteResults().size())
@@ -334,6 +338,8 @@ public class TeamPostService {
 
         return TeamPostDto.VoteInfoWithPk.builder()
                 .votePk(vote.getPk())
+                .title(vote.getTitle())
+                .expiryTime(vote.getExpiryTime())
                 .isMultiVoting(vote.isMultiVoting())
                 .isComplete(vote.isComplete())
                 .voteOptionInfos(vote.getVoteOptions().stream().map(voteOption -> TeamPostDto.VoteOptionInfoWithPk.builder()


### PR DESCRIPTION
# **Pull request**

# Related issue

close #244

---

## Type of change


- [ ] New feature
- [x] Refactor
- [ ] Bug fix
- [ ] Chore
- [ ] Style
- [ ] Test

---

#  📝Description

누락된 투표 관련 데이터(제목, 마감일, 총 참가자 수)  추가
